### PR TITLE
refactor: remove unnecessary canvas id memoization

### DIFF
--- a/app/routes/history.$monthId.tsx
+++ b/app/routes/history.$monthId.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import GameCard from "~/components/GameCard";
 import PitchesModal from "~/components/PitchesModal";
 import ThemeCard from "~/components/ThemeCard";
@@ -70,14 +70,8 @@ export default function HistoryMonth({ loaderData }: Route.ComponentProps) {
 		useState<Nomination | null>(null);
 	const [isViewingPitches, setIsViewingPitches] = useState(false);
 
-	const longGamesCanvasId = useMemo(
-		() => `longGamesChart-${month.month}-${month.year}`,
-		[month],
-	);
-	const shortGamesCanvasId = useMemo(
-		() => `shortGamesChart-${month.month}-${month.year}`,
-		[month],
-	);
+	const longGamesCanvasId = `longGamesChart-${month.month}-${month.year}`;
+	const shortGamesCanvasId = `shortGamesChart-${month.month}-${month.year}`;
 
 	// Only show winners if month status is not "voting"
 	const showWinner =

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import GameCard from "~/components/GameCard";
 import PitchesModal from "~/components/PitchesModal";
 import ThemeCard from "~/components/ThemeCard";
@@ -99,14 +99,8 @@ export default function Index({ loaderData }: Route.ComponentProps) {
 		useState<Nomination | null>(null);
 	const [isViewingPitches, setIsViewingPitches] = useState(false);
 
-	const longGamesCanvasId = useMemo(
-		() => `longGamesChart-${month.month}-${month.year}`,
-		[month],
-	);
-	const shortGamesCanvasId = useMemo(
-		() => `shortGamesChart-${month.month}-${month.year}`,
-		[month],
-	);
+	const longGamesCanvasId = `longGamesChart-${month.month}-${month.year}`;
+	const shortGamesCanvasId = `shortGamesChart-${month.month}-${month.year}`;
 
 	const showWinner =
 		month.status === "over" ||


### PR DESCRIPTION
## Summary
- remove useMemo for canvas IDs on home and history pages
- compute IDs directly from loader data

## Testing
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b576ce0698832f992c196971c84683