### PR TITLE
fix(chart): skip cold-load sankey animation

### DIFF
--- a/app/components/VotingResultsChart.tsx
+++ b/app/components/VotingResultsChart.tsx
@@ -260,6 +260,7 @@ export function VotingResultsChart({
 				series: [
 					{
 						type: "sankey",
+						animationDuration: isPlaying ? 300 : 0,
 						data: nodes,
 						links: links,
 						emphasis: { focus: "adjacency" },
@@ -319,7 +320,7 @@ export function VotingResultsChart({
 		return () => {
 			isActive = false;
 		};
-	}, [activeResults, stableGameColors]);
+	}, [activeResults, isPlaying, stableGameColors]);
 
 	useEffect(() => {
 		if (!isPlaying) return;


### PR DESCRIPTION
## Summary

- disable the expensive initial Sankey animation on page load
- retain a short animation while timelapse playback is active

## Evidence

- cold render: 1,019ms / 1,014ms before; 8ms / 3ms after
- browser smoke: two charts rendered, no console errors

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun test`
- `bun run build`