### PR TITLE
fix(pitches): unblock save UI after pitch edit

### DIFF
--- a/app/components/PitchesModal.tsx
+++ b/app/components/PitchesModal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useRevalidator } from "react-router";
+import { useFetcher } from "react-router";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import {
@@ -10,7 +10,7 @@ import {
 	DialogTitle,
 } from "~/components/ui/dialog";
 import { ScrollArea } from "~/components/ui/scroll-area";
-import type { Nomination } from "~/types";
+import type { Nomination, Pitch } from "~/types";
 
 interface PitchesModalProps {
 	isOpen: boolean;
@@ -23,16 +23,6 @@ interface PitchesModalProps {
 interface PitchMutationResponse {
 	error?: string;
 	success?: boolean;
-}
-
-async function savePitch(nominationId: number, pitch: string): Promise<PitchMutationResponse> {
-	const formData = new FormData();
-	formData.set("intent", "savePitch");
-	formData.set("nominationId", nominationId.toString());
-	formData.set("pitch", pitch);
-
-	const response = await fetch("/nominate", { method: "PATCH", body: formData });
-	return (await response.json()) as PitchMutationResponse;
 }
 
 export default function PitchesModal({
@@ -64,19 +54,43 @@ interface OpenPitchesModalProps {
 	canManagePitch: boolean;
 }
 
+function upsertCurrentUserPitch(
+	pitches: Pitch[],
+	nominationId: number,
+	discordId: string,
+	pitchText: string,
+): Pitch[] {
+	const existingIndex = pitches.findIndex((pitch) => pitch.discordId === discordId);
+	if (existingIndex >= 0) {
+		return pitches.map((pitch, index) =>
+			index === existingIndex ? { ...pitch, pitch: pitchText } : pitch,
+		);
+	}
+
+	return [
+		...pitches,
+		{
+			id: -1,
+			nominationId,
+			discordId,
+			pitch: pitchText,
+			generatedName: "You",
+		},
+	];
+}
+
 function OpenPitchesModal({
 	onClose,
 	nomination,
 	userDiscordId,
 	canManagePitch,
 }: OpenPitchesModalProps) {
-	const revalidator = useRevalidator();
-	const currentUserPitch =
-		nomination.pitches.find((pitch) => pitch.discordId === userDiscordId) ?? null;
+	const fetcher = useFetcher<PitchMutationResponse>();
+	const [pitches, setPitches] = useState(nomination.pitches);
+	const currentUserPitch = pitches.find((pitch) => pitch.discordId === userDiscordId) ?? null;
 	const [isEditorOpen, setIsEditorOpen] = useState(false);
 	const [draftPitch, setDraftPitch] = useState(currentUserPitch?.pitch ?? "");
-	const [saveError, setSaveError] = useState<string | null>(null);
-	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [appliedSuccess, setAppliedSuccess] = useState<PitchMutationResponse | null>(null);
 
 	const handleOpenChange = (open: boolean) => {
 		if (!open) {
@@ -84,26 +98,33 @@ function OpenPitchesModal({
 		}
 	};
 
+	const isSubmitting = fetcher.state !== "idle";
 	const isSaveDisabled = draftPitch.trim().length === 0;
+	const saveError = fetcher.data?.error ?? null;
 
-	const handleSavePitch = async () => {
-		if (isSaveDisabled) {
-			return;
+	if (fetcher.state === "idle" && fetcher.data?.success && fetcher.data !== appliedSuccess) {
+		setAppliedSuccess(fetcher.data);
+		if (userDiscordId) {
+			setPitches((existing) =>
+				upsertCurrentUserPitch(existing, nomination.id, userDiscordId, draftPitch.trim()),
+			);
 		}
-
-		setIsSubmitting(true);
-		setSaveError(null);
-		const result = await savePitch(nomination.id, draftPitch.trim());
-
-		if (result.error) {
-			setSaveError(result.error);
-			setIsSubmitting(false);
-			return;
-		}
-
 		setIsEditorOpen(false);
-		await revalidator.revalidate();
-		setIsSubmitting(false);
+	}
+
+	const handleSavePitch = () => {
+		if (isSaveDisabled || isSubmitting) {
+			return;
+		}
+
+		void fetcher.submit(
+			{
+				intent: "savePitch",
+				nominationId: nomination.id.toString(),
+				pitch: draftPitch.trim(),
+			},
+			{ action: "/nominate", method: "PATCH" },
+		);
 	};
 
 	return (
@@ -116,8 +137,8 @@ function OpenPitchesModal({
 				</DialogHeader>
 				<ScrollArea className="max-h-[65vh] pr-2">
 					<div className="space-y-4">
-						{nomination.pitches.length > 0 ? (
-							nomination.pitches.map((pitch) => {
+						{pitches.length > 0 ? (
+							pitches.map((pitch) => {
 								const isCurrentUserPitch = pitch.discordId === userDiscordId;
 
 								return (
@@ -176,8 +197,9 @@ function OpenPitchesModal({
 									rows={4}
 									value={draftPitch}
 									onChange={(event) => setDraftPitch(event.target.value)}
+									disabled={isSubmitting}
 									placeholder="Why is this game worth playing? What makes it a good fit for the month's theme?"
-									className="flex min-h-[96px] w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+									className="flex min-h-[96px] w-full rounded-md border border-white/10 bg-black/20 px-3 py-2 text-sm text-zinc-200 placeholder:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-60"
 								/>
 								{saveError && <p className="text-sm text-red-400">{saveError}</p>}
 								<div className="flex justify-end gap-2">
@@ -188,6 +210,7 @@ function OpenPitchesModal({
 											setIsEditorOpen(false);
 											setDraftPitch(currentUserPitch?.pitch ?? "");
 										}}
+										disabled={isSubmitting}
 										className="border-gray-600 bg-gray-800/50 text-gray-200 hover:text-white hover:bg-gray-700/70 hover:border-gray-500"
 									>
 										Cancel

--- a/app/components/PitchesModal.tsx
+++ b/app/components/PitchesModal.tsx
@@ -96,8 +96,7 @@ function OpenPitchesModal({
 			: nomination.pitches;
 	const serverUserPitch =
 		nomination.pitches.find((pitch) => pitch.discordId === userDiscordId) ?? null;
-	const currentUserPitch =
-		pitches.find((pitch) => pitch.discordId === userDiscordId) ?? null;
+	const currentUserPitch = pitches.find((pitch) => pitch.discordId === userDiscordId) ?? null;
 	const [isEditorOpen, setIsEditorOpen] = useState(false);
 	const [draftPitch, setDraftPitch] = useState(serverUserPitch?.pitch ?? "");
 

--- a/app/components/PitchesModal.tsx
+++ b/app/components/PitchesModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useFetcher } from "react-router";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -86,11 +86,20 @@ function OpenPitchesModal({
 	canManagePitch,
 }: OpenPitchesModalProps) {
 	const fetcher = useFetcher<PitchMutationResponse>();
-	const [pitches, setPitches] = useState(nomination.pitches);
-	const currentUserPitch = pitches.find((pitch) => pitch.discordId === userDiscordId) ?? null;
+	const pendingPitch =
+		fetcher.formData?.get("intent") === "savePitch"
+			? String(fetcher.formData.get("pitch") ?? "")
+			: null;
+	const pitches =
+		pendingPitch && userDiscordId
+			? upsertCurrentUserPitch(nomination.pitches, nomination.id, userDiscordId, pendingPitch)
+			: nomination.pitches;
+	const serverUserPitch =
+		nomination.pitches.find((pitch) => pitch.discordId === userDiscordId) ?? null;
+	const currentUserPitch =
+		pitches.find((pitch) => pitch.discordId === userDiscordId) ?? null;
 	const [isEditorOpen, setIsEditorOpen] = useState(false);
-	const [draftPitch, setDraftPitch] = useState(currentUserPitch?.pitch ?? "");
-	const [appliedSuccess, setAppliedSuccess] = useState<PitchMutationResponse | null>(null);
+	const [draftPitch, setDraftPitch] = useState(serverUserPitch?.pitch ?? "");
 
 	const handleOpenChange = (open: boolean) => {
 		if (!open) {
@@ -102,30 +111,12 @@ function OpenPitchesModal({
 	const isSaveDisabled = draftPitch.trim().length === 0;
 	const saveError = fetcher.data?.error ?? null;
 
-	if (fetcher.state === "idle" && fetcher.data?.success && fetcher.data !== appliedSuccess) {
-		setAppliedSuccess(fetcher.data);
-		if (userDiscordId) {
-			setPitches((existing) =>
-				upsertCurrentUserPitch(existing, nomination.id, userDiscordId, draftPitch.trim()),
-			);
-		}
-		setIsEditorOpen(false);
-	}
-
-	const handleSavePitch = () => {
-		if (isSaveDisabled || isSubmitting) {
+	useEffect(() => {
+		if (fetcher.state !== "idle" || !fetcher.data?.success) {
 			return;
 		}
-
-		void fetcher.submit(
-			{
-				intent: "savePitch",
-				nominationId: nomination.id.toString(),
-				pitch: draftPitch.trim(),
-			},
-			{ action: "/nominate", method: "PATCH" },
-		);
-	};
+		setIsEditorOpen(false);
+	}, [fetcher.state, fetcher.data]);
 
 	return (
 		<Dialog open onOpenChange={handleOpenChange}>
@@ -143,7 +134,7 @@ function OpenPitchesModal({
 
 								return (
 									<div
-										key={pitch.id}
+										key={pitch.id === -1 ? `pending-${pitch.discordId}` : pitch.id}
 										className={`rounded-xl border p-5 transition-all duration-200 backdrop-blur-sm ${
 											isCurrentUserPitch
 												? "border-emerald-500/50 bg-emerald-500/10 shadow-lg shadow-emerald-950/40"
@@ -187,9 +178,20 @@ function OpenPitchesModal({
 				{canManagePitch && (
 					<div className="border-t border-gray-800 pt-5">
 						{isEditorOpen ? (
-							<div className="space-y-3">
+							<fetcher.Form
+								method="patch"
+								action="/nominate"
+								className="space-y-3"
+								onSubmit={(event) => {
+									if (isSaveDisabled || isSubmitting) {
+										event.preventDefault();
+									}
+								}}
+							>
+								<input type="hidden" name="intent" value="savePitch" />
+								<input type="hidden" name="nominationId" value={nomination.id} />
 								<label htmlFor="pitch-modal-input" className="text-sm font-medium text-gray-200">
-									{currentUserPitch ? "Edit your pitch" : "Add your pitch"}
+									{serverUserPitch ? "Edit your pitch" : "Add your pitch"}
 								</label>
 								<textarea
 									id="pitch-modal-input"
@@ -216,21 +218,20 @@ function OpenPitchesModal({
 										Cancel
 									</Button>
 									<Button
-										type="button"
-										onClick={handleSavePitch}
+										type="submit"
 										disabled={isSaveDisabled || isSubmitting}
 										className="bg-blue-600 text-white hover:bg-blue-700"
 									>
 										{isSubmitting
-											? currentUserPitch
+											? serverUserPitch
 												? "Saving..."
 												: "Adding..."
-											: currentUserPitch
+											: serverUserPitch
 												? "Save Changes"
 												: "Add Pitch"}
 									</Button>
 								</div>
-							</div>
+							</fetcher.Form>
 						) : null}
 					</div>
 				)}
@@ -240,7 +241,10 @@ function OpenPitchesModal({
 							{canManagePitch && !isEditorOpen && (
 								<Button
 									type="button"
-									onClick={() => setIsEditorOpen(true)}
+									onClick={() => {
+										setDraftPitch(currentUserPitch?.pitch ?? "");
+										setIsEditorOpen(true);
+									}}
 									className="bg-blue-600 text-white hover:bg-blue-700"
 								>
 									{currentUserPitch ? "Edit Pitch" : "Add Pitch"}

--- a/app/routes/admin.$monthId.tsx
+++ b/app/routes/admin.$monthId.tsx
@@ -19,6 +19,7 @@ import {
 	categoryLabelsFromMonth,
 	DEFAULT_CATEGORY_LABELS,
 } from "~/utils/categoryLabels";
+import { findNominationById } from "~/utils/nominations";
 import type { Route } from "./+types/admin.$monthId";
 
 const csvField = (value: string | number) => {
@@ -296,8 +297,8 @@ export async function action({ request, url }: Route.ActionArgs) {
 
 export default function Admin({ loaderData }: Route.ComponentProps) {
 	const { months, selectedMonth, nominations, themeCategories } = loaderData;
-	const [selectedNomination, setSelectedNomination] = useState<Nomination | null>(null);
-	const [isPitchesModalOpen, setIsPitchesModalOpen] = useState(false);
+	const [selectedNominationId, setSelectedNominationId] = useState<number | null>(null);
+	const selectedNomination = findNominationById(selectedNominationId, nominations);
 	const createMonthFetcher = useFetcher<ActionResponse>();
 	const statusUpdateFetcher = useFetcher<ActionResponse>();
 	const labelUpdateFetcher = useFetcher<ActionResponse>();
@@ -312,12 +313,10 @@ export default function Admin({ loaderData }: Route.ComponentProps) {
 		setShowCreateForm((previous) => !previous);
 	};
 	const openPitchesModal = (nomination: Nomination) => {
-		setSelectedNomination(nomination);
-		setIsPitchesModalOpen(true);
+		setSelectedNominationId(nomination.id);
 	};
 	const closePitchesModal = () => {
-		setIsPitchesModalOpen(false);
-		setSelectedNomination(null);
+		setSelectedNominationId(null);
 	};
 
 	// Generate unique IDs for form elements
@@ -903,7 +902,7 @@ export default function Admin({ loaderData }: Route.ComponentProps) {
 			)}
 
 			<PitchesModal
-				isOpen={isPitchesModalOpen}
+				isOpen={selectedNomination !== null}
 				onClose={closePitchesModal}
 				nomination={selectedNomination}
 			/>

--- a/app/routes/history.$monthId.tsx
+++ b/app/routes/history.$monthId.tsx
@@ -17,6 +17,7 @@ import {
 import { getWinner } from "~/server/winner.server";
 import type { Nomination } from "~/types";
 import { categoryGameTitle, categoryLabelsFromMonth } from "~/utils/categoryLabels";
+import { findNominationById } from "~/utils/nominations";
 import type { Route } from "./+types/history.$monthId";
 
 type LoaderData = Route.ComponentProps["loaderData"];
@@ -153,15 +154,17 @@ export async function loader({ params }: Route.LoaderArgs) {
 export default function HistoryMonth({ loaderData }: Route.ComponentProps) {
 	const { month, results, gameUrls, nominations, winners, totalVotes } = loaderData;
 	const timelapse = loaderData.timelapse;
-	const [selectedNomination, setSelectedNomination] = useState<Nomination | null>(null);
-	const [isViewingPitches, setIsViewingPitches] = useState(false);
+	const [selectedNominationId, setSelectedNominationId] = useState<number | null>(null);
+	const selectedNomination = findNominationById(
+		selectedNominationId,
+		nominations.long,
+		nominations.short,
+	);
 	const handleViewPitches = (nomination: Nomination) => {
-		setSelectedNomination(nomination);
-		setIsViewingPitches(true);
+		setSelectedNominationId(nomination.id);
 	};
 	const handleCloseModal = () => {
-		setIsViewingPitches(false);
-		setSelectedNomination(null);
+		setSelectedNominationId(null);
 	};
 
 	const columnStatus = {
@@ -274,7 +277,7 @@ export default function HistoryMonth({ loaderData }: Route.ComponentProps) {
 			</div>
 
 			<PitchesModal
-				isOpen={isViewingPitches}
+				isOpen={selectedNomination !== null}
 				onClose={handleCloseModal}
 				nomination={selectedNomination}
 			/>

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -17,6 +17,7 @@ import {
 } from "~/server/voting.server";
 import type { Nomination } from "~/types";
 import { categoryGameTitle, categoryLabelsFromMonth } from "~/utils/categoryLabels";
+import { findNominationById } from "~/utils/nominations";
 import type { Route } from "./+types/home";
 
 type NominationsByType = {
@@ -167,15 +168,17 @@ export async function loader({ context }: Route.LoaderArgs): Promise<LoaderData>
 
 export default function Index({ loaderData }: Route.ComponentProps) {
 	const { month, results, nominations, gameUrls, userDiscordId } = loaderData;
-	const [selectedNomination, setSelectedNomination] = useState<Nomination | null>(null);
-	const [isViewingPitches, setIsViewingPitches] = useState(false);
+	const [selectedNominationId, setSelectedNominationId] = useState<number | null>(null);
+	const selectedNomination = findNominationById(
+		selectedNominationId,
+		nominations?.long,
+		nominations?.short,
+	);
 	const handleViewPitches = (nomination: Nomination) => {
-		setSelectedNomination(nomination);
-		setIsViewingPitches(true);
+		setSelectedNominationId(nomination.id);
 	};
 	const handleCloseModal = () => {
-		setIsViewingPitches(false);
-		setSelectedNomination(null);
+		setSelectedNominationId(null);
 	};
 
 	const columnStatus = nominations
@@ -320,7 +323,7 @@ export default function Index({ loaderData }: Route.ComponentProps) {
 			</div>
 
 			<PitchesModal
-				isOpen={isViewingPitches}
+				isOpen={selectedNomination !== null}
 				onClose={handleCloseModal}
 				nomination={selectedNomination}
 				userDiscordId={userDiscordId}

--- a/app/routes/nominate.tsx
+++ b/app/routes/nominate.tsx
@@ -25,6 +25,7 @@ import {
 	categoryLabelsFromMonth,
 	isDefaultCategoryLabels,
 } from "~/utils/categoryLabels";
+import { findNominationById } from "~/utils/nominations";
 import type { Route } from "./+types/nominate";
 
 interface NominationResponse {
@@ -441,15 +442,23 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 	const [pitch, setPitch] = useState("");
 
 	// State for edit modal
-	const [isEditOpen, setIsEditOpen] = useState(false);
-	const [editingNomination, setEditingNomination] = useState<Nomination | null>(null);
+	const [editingNominationId, setEditingNominationId] = useState<number | null>(null);
 	const [editPitch, setEditPitch] = useState("");
+	const editingNomination = findNominationById(
+		editingNominationId,
+		allNominations,
+		userNominations,
+	);
 
 	// Delete confirmation modal state
-	const [isDeleteOpen, setIsDeleteOpen] = useState(false);
-	const [deletingNomination, setDeletingNomination] = useState<Nomination | null>(null);
-	const [isDeletePitchOpen, setIsDeletePitchOpen] = useState(false);
-	const [pitchToDelete, setPitchToDelete] = useState<Nomination | null>(null);
+	const [deletingNominationId, setDeletingNominationId] = useState<number | null>(null);
+	const [pitchToDeleteId, setPitchToDeleteId] = useState<number | null>(null);
+	const deletingNomination = findNominationById(
+		deletingNominationId,
+		allNominations,
+		userNominations,
+	);
+	const pitchToDelete = findNominationById(pitchToDeleteId, allNominations, userNominations);
 
 	// Track short and long nominations
 	const shortNomination = userNominations.find((n) => n.short);
@@ -498,13 +507,20 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 		: "Search for games…";
 	const searchButtonLabel = shouldUseLocalSearch ? "Filter" : isSearching ? "Searching…" : "Search";
 
-	const [selectedNomination, setSelectedNomination] = useState<Nomination | null>(null);
-	const [isViewingPitches, setIsViewingPitches] = useState(false);
+	const [selectedNominationId, setSelectedNominationId] = useState<number | null>(null);
+	const selectedNomination = findNominationById(
+		selectedNominationId,
+		allNominations,
+		userNominations,
+	);
 	const editingPitchEntry = editingNomination?.pitches.find(
 		(pitchEntry) => pitchEntry.discordId === userDiscordId,
 	);
 	const hasExistingEditingPitch = Boolean(editingPitchEntry);
 	const isSaveDisabled = editPitch.trim().length === 0;
+	const isEditOpen = editingNomination !== null;
+	const isDeleteOpen = deletingNomination !== null;
+	const isDeletePitchOpen = pitchToDelete !== null;
 
 	const handleSearch = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
@@ -544,8 +560,7 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 			return;
 		}
 
-		setDeletingNomination(fullNomination);
-		setIsDeleteOpen(true);
+		setDeletingNominationId(fullNomination.id);
 	};
 
 	const handlePitchEdit = (nomination: Nomination) => {
@@ -553,8 +568,7 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 	};
 
 	const openDeletePitchDialog = (nomination: Nomination) => {
-		setPitchToDelete(nomination);
-		setIsDeletePitchOpen(true);
+		setPitchToDeleteId(nomination.id);
 	};
 
 	const handleEditSubmit = () => {
@@ -571,8 +585,7 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 			{ method: "PATCH" },
 		);
 
-		setIsEditOpen(false);
-		setEditingNomination(null);
+		setEditingNominationId(null);
 		setEditPitch("");
 	};
 
@@ -588,8 +601,7 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 			{ method: "DELETE" },
 		);
 
-		setIsDeleteOpen(false);
-		setDeletingNomination(null);
+		setDeletingNominationId(null);
 	};
 
 	const handleGameLength = (isShort: boolean) => {
@@ -630,33 +642,30 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 	};
 
 	const handleEditDialogOpenChange = (open: boolean) => {
-		setIsEditOpen(open);
 		if (!open) {
+			setEditingNominationId(null);
 			setEditPitch("");
 		}
 	};
 
 	const handleDeleteDialogOpenChange = (open: boolean) => {
-		setIsDeleteOpen(open);
 		if (!open) {
-			setDeletingNomination(null);
+			setDeletingNominationId(null);
 		}
 	};
 
 	const closeEditModal = () => {
-		setIsEditOpen(false);
+		setEditingNominationId(null);
 		setEditPitch("");
 	};
 
 	const closeDeleteModal = () => {
-		setIsDeleteOpen(false);
-		setDeletingNomination(null);
+		setDeletingNominationId(null);
 	};
 
 	const handleDeletePitchDialogOpenChange = (open: boolean) => {
-		setIsDeletePitchOpen(open);
 		if (!open) {
-			setPitchToDelete(null);
+			setPitchToDeleteId(null);
 		}
 	};
 
@@ -673,27 +682,22 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 			{ method: "PATCH" },
 		);
 
-		setIsDeletePitchOpen(false);
-		setPitchToDelete(null);
-		setIsEditOpen(false);
-		setEditingNomination(null);
+		setPitchToDeleteId(null);
+		setEditingNominationId(null);
 		setEditPitch("");
 	};
 
 	const closePitchesModal = () => {
-		setIsViewingPitches(false);
-		setSelectedNomination(null);
+		setSelectedNominationId(null);
 	};
 
 	const handleViewPitches = (nomination: Nomination) => {
-		setSelectedNomination(nomination);
-		setIsViewingPitches(true);
+		setSelectedNominationId(nomination.id);
 	};
 
 	const openNominationModal = (nomination: Nomination) => {
-		setEditingNomination(nomination);
+		setEditingNominationId(nomination.id);
 		setEditPitch(nomination.pitches.find((p) => p.discordId === userDiscordId)?.pitch || "");
-		setIsEditOpen(true);
 	};
 
 	const handleSearchTermChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -1199,7 +1203,7 @@ export default function Nominate({ loaderData }: Route.ComponentProps) {
 
 			{/* Add PitchesModal */}
 			<PitchesModal
-				isOpen={isViewingPitches}
+				isOpen={selectedNomination !== null}
 				onClose={closePitchesModal}
 				nomination={selectedNomination}
 				userDiscordId={userDiscordId}

--- a/app/routes/voting.tsx
+++ b/app/routes/voting.tsx
@@ -1,6 +1,6 @@
 import { DragDropContext, Draggable, Droppable, type DropResult } from "@hello-pangea/dnd";
 import { Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useFetcher } from "react-router";
 import GameCard from "~/components/GameCard";
 import PitchesModal from "~/components/PitchesModal";
@@ -12,7 +12,14 @@ import { getNominationsByIds } from "~/server/nomination.server";
 import type { Nomination } from "~/types";
 import { categoryGameTitle, categoryLabelsFromMonth } from "~/utils/categoryLabels";
 import { findNominationById } from "~/utils/nominations";
+import { buildOrderFromRankings, resolveVotedStatus } from "~/utils/votingOrder";
 import type { Route } from "./+types/voting";
+
+type VoteActionResponse = {
+	success: boolean;
+	error?: string;
+	voteId?: number;
+};
 
 export const middleware: Route.MiddlewareFunction[] = [requireAuthenticatedUser];
 
@@ -253,63 +260,31 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 		userId,
 		shortNominations,
 		longNominations,
-		votedShort: initialVotedShort,
-		votedLong: initialVotedLong,
+		votedShort: loaderVotedShort,
+		votedLong: loaderVotedLong,
 		shortRankings,
 		longRankings,
 		labels,
 	} = loaderData;
 
-	const voteFetcher = useFetcher();
+	const voteFetcher = useFetcher<VoteActionResponse>();
+	const loaderOrder = useMemo(
+		() => ({
+			0: buildOrderFromRankings(longNominations, longRankings),
+			1: buildOrderFromRankings(shortNominations, shortRankings),
+		}),
+		[longNominations, longRankings, shortNominations, shortRankings],
+	);
+	const [currentOrder, setCurrentOrder] = useState(loaderOrder);
 
-	// Initialize order based on existing rankings if available
-	const [currentOrder, setCurrentOrder] = useState<Record<number, string[]>>(() => {
-		const initialOrder: Record<number, string[]> = {
-			0: ["divider"], // long games
-			1: ["divider"], // short games
-		};
-
-		// For long games
-		if (longRankings?.length > 0) {
-			// Add ranked games in order
-			const rankedLongIds = longRankings
-				.sort((a, b) => a.rank - b.rank)
-				.map((r) => String(r.nomination_id));
-			initialOrder[0].unshift(...rankedLongIds);
-
-			// Add remaining unranked games below divider
-			const unrankedLongIds = longNominations
-				.filter((n) => !longRankings.find((r) => r.nomination_id === n.id))
-				.map((n) => String(n.id));
-			initialOrder[0].push(...unrankedLongIds);
-		} else {
-			// If no rankings, all games go below divider
-			initialOrder[0].push(...(longNominations || []).map((n) => String(n.id)));
+	useEffect(() => {
+		if (voteFetcher.state === "idle") {
+			setCurrentOrder(loaderOrder);
 		}
+	}, [voteFetcher.state, loaderOrder]);
 
-		// For short games
-		if (shortRankings?.length > 0) {
-			// Add ranked games in order
-			const rankedShortIds = shortRankings
-				.sort((a, b) => a.rank - b.rank)
-				.map((r) => String(r.nomination_id));
-			initialOrder[1].unshift(...rankedShortIds);
-
-			// Add remaining unranked games below divider
-			const unrankedShortIds = shortNominations
-				.filter((n) => !shortRankings.find((r) => r.nomination_id === n.id))
-				.map((n) => String(n.id));
-			initialOrder[1].push(...unrankedShortIds);
-		} else {
-			// If no rankings, all games go below divider
-			initialOrder[1].push(...(shortNominations || []).map((n) => String(n.id)));
-		}
-
-		return initialOrder;
-	});
-
-	const [votedLong, setVotedLong] = useState(initialVotedLong);
-	const [votedShort, setVotedShort] = useState(initialVotedShort);
+	const votedLong = resolveVotedStatus(Boolean(loaderVotedLong), false, voteFetcher);
+	const votedShort = resolveVotedStatus(Boolean(loaderVotedShort), true, voteFetcher);
 	const [selectedNominationId, setSelectedNominationId] = useState<number | null>(null);
 	const selectedNomination = findNominationById(
 		selectedNominationId,
@@ -323,15 +298,7 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 		setSelectedNominationId(null);
 	};
 
-	const updateVoteStatus = (short: boolean, voted: boolean) => {
-		if (short) {
-			setVotedShort(voted);
-		} else {
-			setVotedLong(voted);
-		}
-	};
-
-	const deleteVote = async (short: boolean) => {
+	const deleteVote = (short: boolean) => {
 		void voteFetcher.submit(
 			{ short },
 			{ method: "DELETE", action: "/api/votes", encType: "application/json" },
@@ -342,19 +309,17 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 
 		setCurrentOrder((prev) => ({
 			...prev,
-			[shortKey]: ["divider", ...games.map((n) => String(n.id))],
+			[shortKey]: ["divider", ...(games ?? []).map((n) => String(n.id))],
 		}));
-
-		updateVoteStatus(short, false);
 	};
 
-	const saveVote = async (short: boolean, order: string[]) => {
+	const saveVote = (short: boolean, order: string[]) => {
 		const validOrder = order
 			.filter((id) => id && id !== "divider")
 			.map((id) => Number.parseInt(id, 10));
 
 		if (validOrder.length === 0) {
-			await deleteVote(short);
+			deleteVote(short);
 			return;
 		}
 
@@ -366,11 +331,9 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 				encType: "application/json",
 			},
 		);
-
-		updateVoteStatus(short, true);
 	};
 
-	const onDragEnd = async (result: DropResult) => {
+	const onDragEnd = (result: DropResult) => {
 		if (!result.destination) return;
 
 		const isShort = result.source.droppableId === "short";
@@ -386,13 +349,13 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 		const rankedItems = items.slice(0, newDividerIndex);
 
 		if (rankedItems.length > 0) {
-			await saveVote(isShort, rankedItems);
+			saveVote(isShort, rankedItems);
 		} else {
-			await deleteVote(isShort);
+			deleteVote(isShort);
 		}
 	};
 
-	const moveItemAboveDivider = async (isShort: boolean, itemId: string) => {
+	const moveItemAboveDivider = (isShort: boolean, itemId: string) => {
 		const shortKey = isShort ? 1 : 0;
 		const items = Array.from(currentOrder[shortKey]);
 
@@ -406,11 +369,11 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 		setCurrentOrder((prevOrder) => ({ ...prevOrder, [shortKey]: items }));
 		const rankedItems = items.slice(0, items.indexOf("divider"));
 		if (rankedItems.length > 0) {
-			await saveVote(isShort, rankedItems);
+			saveVote(isShort, rankedItems);
 		}
 	};
 
-	const moveItemBelowDivider = async (isShort: boolean, itemId: string) => {
+	const moveItemBelowDivider = (isShort: boolean, itemId: string) => {
 		const shortKey = isShort ? 1 : 0;
 		const items = Array.from(currentOrder[shortKey]);
 
@@ -424,9 +387,9 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 		setCurrentOrder((prevOrder) => ({ ...prevOrder, [shortKey]: items }));
 		const rankedItems = items.slice(0, dividerIndex);
 		if (rankedItems.length > 0) {
-			await saveVote(isShort, rankedItems);
+			saveVote(isShort, rankedItems);
 		} else {
-			await deleteVote(isShort);
+			deleteVote(isShort);
 		}
 	};
 
@@ -442,11 +405,11 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 	};
 
 	const handleClearLongVote = () => {
-		void deleteVote(false);
+		deleteVote(false);
 	};
 
 	const handleClearShortVote = () => {
-		void deleteVote(true);
+		deleteVote(true);
 	};
 
 	const longAction = votedLong ? (
@@ -493,10 +456,10 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 						order={currentOrder[0]}
 						onViewPitches={handleOpenPitches}
 						onRank={(itemId) => {
-							void moveItemAboveDivider(false, itemId);
+							moveItemAboveDivider(false, itemId);
 						}}
 						onUnrank={(itemId) => {
-							void moveItemBelowDivider(false, itemId);
+							moveItemBelowDivider(false, itemId);
 						}}
 					/>
 				</DragDropContext>
@@ -514,10 +477,10 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 						order={currentOrder[1]}
 						onViewPitches={handleOpenPitches}
 						onRank={(itemId) => {
-							void moveItemAboveDivider(true, itemId);
+							moveItemAboveDivider(true, itemId);
 						}}
 						onUnrank={(itemId) => {
-							void moveItemBelowDivider(true, itemId);
+							moveItemBelowDivider(true, itemId);
 						}}
 					/>
 				</DragDropContext>

--- a/app/routes/voting.tsx
+++ b/app/routes/voting.tsx
@@ -11,6 +11,7 @@ import { getCurrentMonth } from "~/server/month.server";
 import { getNominationsByIds } from "~/server/nomination.server";
 import type { Nomination } from "~/types";
 import { categoryGameTitle, categoryLabelsFromMonth } from "~/utils/categoryLabels";
+import { findNominationById } from "~/utils/nominations";
 import type { Route } from "./+types/voting";
 
 export const middleware: Route.MiddlewareFunction[] = [requireAuthenticatedUser];
@@ -309,15 +310,17 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 
 	const [votedLong, setVotedLong] = useState(initialVotedLong);
 	const [votedShort, setVotedShort] = useState(initialVotedShort);
-	const [selectedNomination, setSelectedNomination] = useState<Nomination | null>(null);
-	const [isViewingPitches, setIsViewingPitches] = useState(false);
+	const [selectedNominationId, setSelectedNominationId] = useState<number | null>(null);
+	const selectedNomination = findNominationById(
+		selectedNominationId,
+		longNominations,
+		shortNominations,
+	);
 	const handleOpenPitches = (nomination: Nomination) => {
-		setSelectedNomination(nomination);
-		setIsViewingPitches(true);
+		setSelectedNominationId(nomination.id);
 	};
 	const closePitchesModal = () => {
-		setIsViewingPitches(false);
-		setSelectedNomination(null);
+		setSelectedNominationId(null);
 	};
 
 	const updateVoteStatus = (short: boolean, voted: boolean) => {
@@ -521,7 +524,7 @@ export default function Voting({ loaderData }: Route.ComponentProps) {
 			</Column>
 
 			<PitchesModal
-				isOpen={isViewingPitches}
+				isOpen={selectedNomination !== null}
 				onClose={closePitchesModal}
 				nomination={selectedNomination}
 				userDiscordId={userId}

--- a/app/utils/nominations.test.ts
+++ b/app/utils/nominations.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import type { Nomination } from "~/types";
+import { findNominationById } from "~/utils/nominations";
+
+function nomination(id: number, gameName: string): Nomination {
+	return {
+		id,
+		gameId: String(id),
+		short: false,
+		jurySelected: false,
+		monthId: 1,
+		gameName,
+		gameYear: "2024",
+		gameUrl: "",
+		discordId: "1",
+		pitches: [],
+	};
+}
+
+describe("findNominationById", () => {
+	test("returns null for null id", () => {
+		expect(findNominationById(null, [nomination(1, "A")])).toBeNull();
+	});
+
+	test("finds across lists", () => {
+		const long = [nomination(1, "Long")];
+		const short = [nomination(2, "Short")];
+		expect(findNominationById(2, long, short)?.gameName).toBe("Short");
+	});
+
+	test("returns null when missing", () => {
+		expect(findNominationById(9, [nomination(1, "A")], undefined)).toBeNull();
+	});
+});

--- a/app/utils/nominations.ts
+++ b/app/utils/nominations.ts
@@ -1,0 +1,19 @@
+import type { Nomination } from "~/types";
+
+export function findNominationById(
+	id: number | null | undefined,
+	...lists: readonly (readonly Nomination[] | null | undefined)[]
+): Nomination | null {
+	if (id == null) {
+		return null;
+	}
+
+	for (const list of lists) {
+		const match = list?.find((nomination) => nomination.id === id);
+		if (match) {
+			return match;
+		}
+	}
+
+	return null;
+}

--- a/app/utils/votingOrder.test.ts
+++ b/app/utils/votingOrder.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import type { Nomination } from "~/types";
+import { buildOrderFromRankings, resolveVotedStatus } from "~/utils/votingOrder";
+
+function nomination(id: number): Nomination {
+	return {
+		id,
+		gameId: String(id),
+		short: false,
+		jurySelected: true,
+		monthId: 1,
+		gameName: `Game ${id}`,
+		gameYear: "2024",
+		gameUrl: "",
+		discordId: "1",
+		pitches: [],
+	};
+}
+
+describe("buildOrderFromRankings", () => {
+	test("all unranked without rankings", () => {
+		expect(buildOrderFromRankings([nomination(1), nomination(2)], [])).toEqual([
+			"divider",
+			"1",
+			"2",
+		]);
+	});
+
+	test("ranked then divider then unranked", () => {
+		expect(
+			buildOrderFromRankings(
+				[nomination(1), nomination(2), nomination(3)],
+				[
+					{ nomination_id: 3, rank: 2 },
+					{ nomination_id: 1, rank: 1 },
+				],
+			),
+		).toEqual(["1", "3", "divider", "2"]);
+	});
+});
+
+describe("resolveVotedStatus", () => {
+	test("idle uses loader value", () => {
+		expect(resolveVotedStatus(true, true, { state: "idle" })).toBe(true);
+		expect(resolveVotedStatus(false, true, { state: "idle" })).toBe(false);
+	});
+
+	test("pending delete clears vote for matching column", () => {
+		expect(
+			resolveVotedStatus(true, true, {
+				state: "submitting",
+				formMethod: "DELETE",
+				json: { short: true },
+			}),
+		).toBe(false);
+	});
+
+	test("pending post sets voted for matching column only", () => {
+		expect(
+			resolveVotedStatus(false, false, {
+				state: "submitting",
+				formMethod: "POST",
+				json: { short: false, order: [1] },
+			}),
+		).toBe(true);
+		expect(
+			resolveVotedStatus(false, true, {
+				state: "submitting",
+				formMethod: "POST",
+				json: { short: false, order: [1] },
+			}),
+		).toBe(false);
+	});
+});

--- a/app/utils/votingOrder.ts
+++ b/app/utils/votingOrder.ts
@@ -1,0 +1,58 @@
+import type { Nomination } from "~/types";
+
+export type RankingRow = {
+	nomination_id: number;
+	rank: number;
+};
+
+export function buildOrderFromRankings(
+	nominations: Nomination[] | undefined,
+	rankings: RankingRow[] | undefined,
+): string[] {
+	const games = nominations ?? [];
+	if (!rankings?.length) {
+		return ["divider", ...games.map((nomination) => String(nomination.id))];
+	}
+
+	const rankedIds = [...rankings]
+		.sort((a, b) => a.rank - b.rank)
+		.map((ranking) => String(ranking.nomination_id));
+	const rankedSet = new Set(rankedIds);
+	const unrankedIds = games
+		.filter((nomination) => !rankedSet.has(String(nomination.id)))
+		.map((nomination) => String(nomination.id));
+
+	return [...rankedIds, "divider", ...unrankedIds];
+}
+
+export function resolveVotedStatus(
+	loaderVoted: boolean,
+	short: boolean,
+	submission: {
+		state: "idle" | "submitting" | "loading";
+		formMethod?: string;
+		json?: unknown;
+	},
+): boolean {
+	if (submission.state === "idle") {
+		return loaderVoted;
+	}
+
+	const body = submission.json;
+	if (
+		typeof body !== "object" ||
+		body === null ||
+		Array.isArray(body) ||
+		!("short" in body) ||
+		typeof body.short !== "boolean" ||
+		body.short !== short
+	) {
+		return loaderVoted;
+	}
+
+	if (submission.formMethod === "DELETE") {
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Pitch save stuck on **Saving...**: plain `fetch("/nominate")` got HTML after a successful write. Now `fetcher.Form` + `useFetcher`.
- Stale nomination snapshots: hosts store `nominationId` and resolve via `findNominationById` against revalidated loader data (home, nominate, voting, history, admin). Nominate edit/delete modals too.
- PitchesModal optimistic UI via `fetcher.formData`; list from loader nomination after revalidation.
- Voting badges/order: `voted*` derived from loader + `voteFetcher.json`; order resyncs from rankings when the vote fetcher settles (failed saves revert).

## Test plan
- [ ] Nominating: pitches modal edit → Saving clears, text updates without refresh
- [ ] Home (nominating): same
- [ ] Nominate edit-pitch dialog still saves
- [ ] Voting: rank games → Voted badge; clear vote → Not Voted; failed network/revalidate should not leave a stuck Voted badge / wrong order
- [ ] Voting/history/admin: view pitches still opens the right game
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa075-8c97-77e0-8222-fedb5740f7d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa075-8c97-77e0-8222-fedb5740f7d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

