### PR TITLE
feat(seo): make the archive discoverable and link previews rich

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,8 @@ COPY --from=build /app/server.js /app/server.js
 COPY --from=build /app/build /app/build
 COPY --from=build /app/public /app/public
 COPY --from=production-deps /app/node_modules/@libsql /app/node_modules/@libsql
+# Social card rendering reads the resvg wasm binary and Inter woff files at runtime.
+COPY --from=production-deps /app/node_modules/@resvg /app/node_modules/@resvg
+COPY --from=production-deps /app/node_modules/@fontsource /app/node_modules/@fontsource
 
 CMD ["bun", "server.js"]

--- a/app/components/ClubIntro.tsx
+++ b/app/components/ClubIntro.tsx
@@ -1,0 +1,29 @@
+import { DISCORD_INVITE_URL } from "~/utils/seo";
+
+export default function ClubIntro() {
+	return (
+		<section className="mb-10 text-center">
+			<h1 className="text-3xl font-bold tracking-tight text-zinc-100 sm:text-4xl">
+				PatientGamers Game of the Month
+			</h1>
+			<p className="mx-auto mt-4 max-w-2xl text-base text-zinc-300 sm:text-lg">
+				Every month the PatientGamers Discord plays two games together: one short, under 12 hours on
+				HowLongToBeat, and one long. Anyone can nominate a game that fits the month&apos;s theme,
+				the jury narrows the nominations down to a ballot, and members rank their favourites. The
+				winner is decided by instant-runoff voting.
+			</p>
+			<p className="mx-auto mt-3 max-w-2xl text-base text-zinc-400">
+				No signups, no schedule to keep up with — play at your own pace and talk about it when you
+				get there.
+			</p>
+			<a
+				href={DISCORD_INVITE_URL}
+				target="_blank"
+				rel="noopener noreferrer"
+				className="mt-6 inline-flex items-center justify-center rounded-lg bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white no-underline transition-colors hover:bg-indigo-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-900"
+			>
+				Join the Discord
+			</a>
+		</section>
+	);
+}

--- a/app/components/ClubIntro.tsx
+++ b/app/components/ClubIntro.tsx
@@ -7,14 +7,13 @@ export default function ClubIntro() {
 				PatientGamers Game of the Month
 			</h1>
 			<p className="mx-auto mt-4 max-w-2xl text-base text-zinc-300 sm:text-lg">
-				Every month the PatientGamers Discord plays two games together: one short, under 12 hours on
-				HowLongToBeat, and one long. Anyone can nominate a game that fits the month&apos;s theme,
-				the jury narrows the nominations down to a ballot, and members rank their favourites. The
-				winner is decided by instant-runoff voting.
+				Every month the PatientGamers Discord picks two games to play. One is under 12 hours on
+				HowLongToBeat and one is longer. The jury sets a theme, anyone can nominate a game that fits
+				it, then the jury cuts the nominations down to a ballot. Members rank that ballot and
+				instant-runoff voting decides the winners.
 			</p>
 			<p className="mx-auto mt-3 max-w-2xl text-base text-zinc-400">
-				No signups, no schedule to keep up with — play at your own pace and talk about it when you
-				get there.
+				Nothing is scheduled. Play the winners whenever you get to them.
 			</p>
 			<a
 				href={DISCORD_INVITE_URL}

--- a/app/components/GameCardImage.tsx
+++ b/app/components/GameCardImage.tsx
@@ -37,6 +37,8 @@ export function GameCardImage({ coverUrl, gameName, status }: GameCardImageProps
 						alt={gameName}
 						width={156}
 						height={208}
+						loading="lazy"
+						decoding="async"
 						className={cn(
 							"h-full w-full object-cover transition-all duration-500 group-hover:scale-105",
 							status === "winner"

--- a/app/components/ThemeCard.tsx
+++ b/app/components/ThemeCard.tsx
@@ -1,10 +1,17 @@
 import React from "react";
 import type { Month } from "~/types";
 
-export default function ThemeCard(month: Month) {
+interface ThemeCardProps extends Month {
+	/** On an archive page the month and theme are the page heading; on the home
+	 * page that role belongs to the club introduction above it. */
+	asPageHeading?: boolean;
+}
+
+export default function ThemeCard({ asPageHeading = false, ...month }: ThemeCardProps) {
 	const monthName = new Date(month.year, month.month - 1).toLocaleString("default", {
 		month: "long",
 	});
+	const Heading = asPageHeading ? "h1" : "div";
 
 	return (
 		<div className="w-full">
@@ -12,11 +19,11 @@ export default function ThemeCard(month: Month) {
 				<div className="relative px-8 pt-10 rounded-2xl">
 					<div className="flex flex-col items-center text-center space-y-8">
 						{/* Month and Year */}
-						<div className="flex flex-col items-center gap-3">
+						<Heading className="flex flex-col items-center gap-3 m-0">
 							<span className="text-4xl font-bold tracking-wider">{monthName}</span>
 							<span className="text-xl font-bold">{month.year}</span>
 							<span className="px-4 py-1 rounded-full bg-blue-600">{month.theme.name}</span>
-						</div>
+						</Heading>
 
 						{month.theme.description && (
 							<p className="text-lg leading-relaxed whitespace-pre-wrap">

--- a/app/components/TwoColumnLayout.tsx
+++ b/app/components/TwoColumnLayout.tsx
@@ -57,8 +57,8 @@ export default function TwoColumnLayout({
 	return (
 		<div className="mx-auto">
 			<div className="text-center space-y-2 mb-8">
-				<h1 className="text-3xl font-bold">{title}</h1>
-				{subtitle && <h2 className="text-xl text-muted-foreground">{subtitle}</h2>}
+				<h2 className="text-3xl font-bold">{title}</h2>
+				{subtitle && <p className="text-xl text-muted-foreground">{subtitle}</p>}
 				{description && <p className="text-muted-foreground">{description}</p>}
 			</div>
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -22,7 +22,7 @@ export const meta: Route.MetaFunction = () =>
 	pageMeta({
 		title: SITE_NAME,
 		description:
-			"The PatientGamers Discord plays one short game and one long game together every month. Nominate, vote, and play along.",
+			"The PatientGamers Discord picks two games to play every month, one short and one long.",
 		path: "/",
 	});
 
@@ -37,7 +37,7 @@ const siteSchema = {
 			url: SITE_URL,
 			name: SITE_NAME,
 			description:
-				"A monthly game club run by the PatientGamers Discord: one short game, one long game, chosen by ranked-choice vote.",
+				"The PatientGamers Discord picks two games to play every month, one short and one long. Winners are decided by instant-runoff voting.",
 			inLanguage: "en",
 			publisher: { "@id": `${SITE_URL}/#organization` },
 		},

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,33 +1,56 @@
 import React from "react";
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
 import { loadRequestUser } from "~/route-context.server";
+import { DISCORD_INVITE_URL, SITE_NAME, SITE_URL, absoluteUrl, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/root";
 import "./tailwind.css";
 
 export const middleware: Route.MiddlewareFunction[] = [loadRequestUser];
 
-export const meta: Route.MetaFunction = () => {
-	return [
-		{ title: "PG GOTM" },
+export const links: Route.LinksFunction = () => [
+	{ rel: "icon", href: "/favicon.ico", sizes: "any" },
+	{ rel: "icon", href: "/favicon-32x32.png", type: "image/png", sizes: "32x32" },
+	{ rel: "icon", href: "/favicon-16x16.png", type: "image/png", sizes: "16x16" },
+	{ rel: "apple-touch-icon", href: "/apple-touch-icon.png", sizes: "180x180" },
+	{ rel: "manifest", href: "/site.webmanifest" },
+	// Every game cover is served from IGDB.
+	{ rel: "preconnect", href: "https://images.igdb.com" },
+];
+
+// Fallback for routes without their own meta. Every public route overrides this.
+export const meta: Route.MetaFunction = () =>
+	pageMeta({
+		title: SITE_NAME,
+		description:
+			"The PatientGamers Discord plays one short game and one long game together every month. Nominate, vote, and play along.",
+		path: "/",
+	});
+
+// Site-wide structured data. Lives in the document rather than in `meta` so it
+// survives routes that export their own meta.
+const siteSchema = {
+	"@context": "https://schema.org",
+	"@graph": [
 		{
-			name: "description",
-			content: "Vote for the PG Discord Game of the Month!",
+			"@type": "WebSite",
+			"@id": `${SITE_URL}/#website`,
+			url: SITE_URL,
+			name: SITE_NAME,
+			description:
+				"A monthly game club run by the PatientGamers Discord: one short game, one long game, chosen by ranked-choice vote.",
+			inLanguage: "en",
+			publisher: { "@id": `${SITE_URL}/#organization` },
 		},
-		{ name: "theme-color", content: "#18181B" }, // zinc-900 color
-		{ property: "og:title", content: "PG Game of the Month" },
 		{
-			property: "og:description",
-			content: "Vote for the PG Discord Game of the Month!",
+			"@type": "Organization",
+			"@id": `${SITE_URL}/#organization`,
+			name: SITE_NAME,
+			alternateName: "PG GOTM",
+			url: SITE_URL,
+			logo: absoluteUrl("/android-chrome-512x512.png"),
+			sameAs: [DISCORD_INVITE_URL, "https://github.com/obviyus/gotm-remix"],
 		},
-		{ property: "og:type", content: "website" },
-		{ property: "og:url", content: "https://pg-gotm.com" },
-		{ name: "twitter:card", content: "summary_large_image" },
-		{ name: "twitter:title", content: "PG GOTM" },
-		{
-			name: "twitter:description",
-			content: "Vote for and discover the PG Discord Game of the Month!",
-		},
-	];
+	],
 };
 
 export function Layout({ children }: { children: React.ReactNode }) {
@@ -36,8 +59,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
 			<head>
 				<meta charSet="utf-8" />
 				<meta name="viewport" content="width=device-width, initial-scale=1" />
+				<meta name="theme-color" content="#18181B" />
 				<Meta />
 				<Links />
+				<script
+					type="application/ld+json"
+					dangerouslySetInnerHTML={{ __html: JSON.stringify(siteSchema) }}
+				/>
 			</head>
 			<body className="relative prose lg:prose-xl bg-zinc-900 text-zinc-100">
 				<div className="isolate">{children}</div>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -47,4 +47,11 @@ export default [
 
 	// API routes
 	...prefix("api", [route("votes", "./routes/api.votes.ts")]),
+
+	// Crawler-facing resources, served outside the layout
+	route("robots.txt", "./routes/robots.ts"),
+	route("sitemap.xml", "./routes/sitemap.ts"),
+
+	// Social card images
+	...prefix("og", [index("./routes/og.tsx"), route("month/:monthId", "./routes/og.month.tsx")]),
 ] satisfies RouteConfig;

--- a/app/routes/admin.$monthId.tsx
+++ b/app/routes/admin.$monthId.tsx
@@ -20,7 +20,16 @@ import {
 	DEFAULT_CATEGORY_LABELS,
 } from "~/utils/categoryLabels";
 import { findNominationById } from "~/utils/nominations";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/admin.$monthId";
+
+export const meta: Route.MetaFunction = () =>
+	pageMeta({
+		title: `Manage Month — ${SITE_NAME}`,
+		description: "Jury tools.",
+		path: "/admin",
+		noIndex: true,
+	});
 
 const csvField = (value: string | number) => {
 	const text = String(value)

--- a/app/routes/admin.$monthId.tsx
+++ b/app/routes/admin.$monthId.tsx
@@ -25,7 +25,7 @@ import type { Route } from "./+types/admin.$monthId";
 
 export const meta: Route.MetaFunction = () =>
 	pageMeta({
-		title: `Manage Month — ${SITE_NAME}`,
+		title: `Manage Month | ${SITE_NAME}`,
 		description: "Jury tools.",
 		path: "/admin",
 		noIndex: true,

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -2,7 +2,16 @@ import React from "react";
 import { redirect } from "react-router";
 import { requireAdmin, requireAuthenticatedUser } from "~/route-context.server";
 import { getCurrentMonth } from "~/server/month.server";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/admin";
+
+export const meta: Route.MetaFunction = () =>
+	pageMeta({
+		title: `Admin — ${SITE_NAME}`,
+		description: "Jury tools.",
+		path: "/admin",
+		noIndex: true,
+	});
 
 export const middleware: Route.MiddlewareFunction[] = [requireAuthenticatedUser, requireAdmin];
 

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -7,7 +7,7 @@ import type { Route } from "./+types/admin";
 
 export const meta: Route.MetaFunction = () =>
 	pageMeta({
-		title: `Admin — ${SITE_NAME}`,
+		title: `Admin | ${SITE_NAME}`,
 		description: "Jury tools.",
 		path: "/admin",
 		noIndex: true,

--- a/app/routes/history.$monthId.tsx
+++ b/app/routes/history.$monthId.tsx
@@ -18,7 +18,7 @@ import { getWinner } from "~/server/winner.server";
 import type { Nomination } from "~/types";
 import { categoryGameTitle, categoryLabelsFromMonth } from "~/utils/categoryLabels";
 import { findNominationById } from "~/utils/nominations";
-import { SITE_NAME, absoluteImageUrl, monthLabel, pageMeta } from "~/utils/seo";
+import { SITE_NAME, absoluteUrl, monthLabel, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/history.$monthId";
 
 type LoaderData = Route.ComponentProps["loaderData"];
@@ -175,7 +175,7 @@ export const meta: Route.MetaFunction = ({ loaderData }) => {
 				"@type": "VideoGame",
 				name: nomination.gameName,
 				...(nomination.gameUrl ? { sameAs: nomination.gameUrl } : {}),
-				...(nomination.gameCover ? { image: absoluteImageUrl(nomination.gameCover) } : {}),
+				...(nomination.gameCover ? { image: absoluteUrl(nomination.gameCover) } : {}),
 			},
 		})),
 	};

--- a/app/routes/history.$monthId.tsx
+++ b/app/routes/history.$monthId.tsx
@@ -160,13 +160,13 @@ export const meta: Route.MetaFunction = ({ loaderData }) => {
 	const winnerNames = [winners.long?.gameName, winners.short?.gameName].filter(Boolean);
 
 	const description = winnerNames.length
-		? `${winnerNames.join(" and ")} won the "${month.theme.name}" theme in ${label}. See all ${allNominations.length} nominated games, member pitches, and the full ranked-choice results.`
-		: `${allNominations.length} games nominated for the "${month.theme.name}" theme in ${label}, the PatientGamers monthly game club.`;
+		? `${winnerNames.join(" and ")} won the "${month.theme.name}" theme in ${label}, out of ${allNominations.length} games nominated by the PatientGamers Discord.`
+		: `${allNominations.length} games nominated by the PatientGamers Discord for the "${month.theme.name}" theme in ${label}.`;
 
 	const itemList = {
 		"@context": "https://schema.org",
 		"@type": "ItemList",
-		name: `${label} nominations — ${month.theme.name}`,
+		name: `${label} nominations for ${month.theme.name}`,
 		numberOfItems: allNominations.length,
 		itemListElement: allNominations.map((nomination, index) => ({
 			"@type": "ListItem",
@@ -182,7 +182,7 @@ export const meta: Route.MetaFunction = ({ loaderData }) => {
 
 	return [
 		...pageMeta({
-			title: `${label}: ${month.theme.name} — ${SITE_NAME}`,
+			title: `${label}: ${month.theme.name} | ${SITE_NAME}`,
 			description,
 			path,
 			image: `/og/month/${month.id}`,

--- a/app/routes/history.$monthId.tsx
+++ b/app/routes/history.$monthId.tsx
@@ -18,6 +18,7 @@ import { getWinner } from "~/server/winner.server";
 import type { Nomination } from "~/types";
 import { categoryGameTitle, categoryLabelsFromMonth } from "~/utils/categoryLabels";
 import { findNominationById } from "~/utils/nominations";
+import { SITE_NAME, absoluteImageUrl, monthLabel, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/history.$monthId";
 
 type LoaderData = Route.ComponentProps["loaderData"];
@@ -151,6 +152,45 @@ export async function loader({ params }: Route.LoaderArgs) {
 	};
 }
 
+export const meta: Route.MetaFunction = ({ loaderData }) => {
+	const { month, nominations, winners } = loaderData;
+	const label = monthLabel(month.month, month.year);
+	const path = `/history/${month.id}`;
+	const allNominations = [...nominations.long, ...nominations.short];
+	const winnerNames = [winners.long?.gameName, winners.short?.gameName].filter(Boolean);
+
+	const description = winnerNames.length
+		? `${winnerNames.join(" and ")} won the "${month.theme.name}" theme in ${label}. See all ${allNominations.length} nominated games, member pitches, and the full ranked-choice results.`
+		: `${allNominations.length} games nominated for the "${month.theme.name}" theme in ${label}, the PatientGamers monthly game club.`;
+
+	const itemList = {
+		"@context": "https://schema.org",
+		"@type": "ItemList",
+		name: `${label} nominations — ${month.theme.name}`,
+		numberOfItems: allNominations.length,
+		itemListElement: allNominations.map((nomination, index) => ({
+			"@type": "ListItem",
+			position: index + 1,
+			item: {
+				"@type": "VideoGame",
+				name: nomination.gameName,
+				...(nomination.gameUrl ? { sameAs: nomination.gameUrl } : {}),
+				...(nomination.gameCover ? { image: absoluteImageUrl(nomination.gameCover) } : {}),
+			},
+		})),
+	};
+
+	return [
+		...pageMeta({
+			title: `${label}: ${month.theme.name} — ${SITE_NAME}`,
+			description,
+			path,
+			image: `/og/month/${month.id}`,
+		}),
+		{ "script:ld+json": itemList },
+	];
+};
+
 export default function HistoryMonth({ loaderData }: Route.ComponentProps) {
 	const { month, results, gameUrls, nominations, winners, totalVotes } = loaderData;
 	const timelapse = loaderData.timelapse;
@@ -208,7 +248,9 @@ export default function HistoryMonth({ loaderData }: Route.ComponentProps) {
 
 	return (
 		<div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
-			<div className="text-center space-y-2 mb-8">{month.theme && <ThemeCard {...month} />}</div>
+			<div className="text-center space-y-2 mb-8">
+				{month.theme && <ThemeCard {...month} asPageHeading />}
+			</div>
 
 			{month.status === "voting" ? (
 				<div className="bg-amber-900/30 border border-amber-700/50 rounded-lg p-6 text-center space-y-4">

--- a/app/routes/history.tsx
+++ b/app/routes/history.tsx
@@ -7,7 +7,18 @@ import { db } from "~/server/database.server";
 import { getMonths } from "~/server/month.server";
 import type { Month, Nomination } from "~/types";
 import { categoryWinnerLabel } from "~/utils/categoryLabels";
+import { pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/history";
+
+export const meta: Route.MetaFunction = ({ loaderData }) => {
+	const count = loaderData.months.length;
+
+	return pageMeta({
+		title: "Every Past Winner — PG Game of the Month",
+		description: `All ${count} ${count === 1 ? "month" : "months"} of the PatientGamers game club: monthly themes, every nominated game, and the short and long winners the community voted for.`,
+		path: "/history",
+	});
+};
 
 export async function loader() {
 	const [allMonths, winnersResult] = await Promise.all([

--- a/app/routes/history.tsx
+++ b/app/routes/history.tsx
@@ -7,18 +7,16 @@ import { db } from "~/server/database.server";
 import { getMonths } from "~/server/month.server";
 import type { Month, Nomination } from "~/types";
 import { categoryWinnerLabel } from "~/utils/categoryLabels";
-import { pageMeta } from "~/utils/seo";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/history";
 
-export const meta: Route.MetaFunction = ({ loaderData }) => {
-	const count = loaderData.months.length;
-
-	return pageMeta({
-		title: "Every Past Winner — PG Game of the Month",
-		description: `All ${count} ${count === 1 ? "month" : "months"} of the PatientGamers game club: monthly themes, every nominated game, and the short and long winners the community voted for.`,
+export const meta: Route.MetaFunction = () =>
+	pageMeta({
+		title: `Past Winners | ${SITE_NAME}`,
+		description:
+			"Every month the PatientGamers Discord has played, with the theme and the winning games for each.",
 		path: "/history",
 	});
-};
 
 export async function loader() {
 	const [allMonths, winnersResult] = await Promise.all([

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -172,8 +172,8 @@ export const meta: Route.MetaFunction = ({ loaderData }) => {
 	const { month } = loaderData;
 
 	return pageMeta({
-		title: "PG Game of the Month — A PatientGamers Game Club",
-		description: `This month's theme is "${month.theme.name}". The PatientGamers Discord picks one short game and one long game to play together every month — nominate, vote, play along.`,
+		title: "PatientGamers Game of the Month",
+		description: `The PatientGamers Discord picks two games to play every month, one short and one long. This month's theme is "${month.theme.name}".`,
 		path: "/",
 		image: `/og/month/${month.id}`,
 	});

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router";
+import ClubIntro from "~/components/ClubIntro";
 import GameCard from "~/components/GameCard";
 import PitchesModal from "~/components/PitchesModal";
 import ThemeCard from "~/components/ThemeCard";
@@ -18,6 +19,7 @@ import {
 import type { Nomination } from "~/types";
 import { categoryGameTitle, categoryLabelsFromMonth } from "~/utils/categoryLabels";
 import { findNominationById } from "~/utils/nominations";
+import { pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/home";
 
 type NominationsByType = {
@@ -166,6 +168,17 @@ export async function loader({ context }: Route.LoaderArgs): Promise<LoaderData>
 	}
 }
 
+export const meta: Route.MetaFunction = ({ loaderData }) => {
+	const { month } = loaderData;
+
+	return pageMeta({
+		title: "PG Game of the Month — A PatientGamers Game Club",
+		description: `This month's theme is "${month.theme.name}". The PatientGamers Discord picks one short game and one long game to play together every month — nominate, vote, play along.`,
+		path: "/",
+		image: `/og/month/${month.id}`,
+	});
+};
+
 export default function Index({ loaderData }: Route.ComponentProps) {
 	const { month, results, nominations, gameUrls, userDiscordId } = loaderData;
 	const [selectedNominationId, setSelectedNominationId] = useState<number | null>(null);
@@ -224,6 +237,7 @@ export default function Index({ loaderData }: Route.ComponentProps) {
 
 	return (
 		<div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+			<ClubIntro />
 			<div className="text-center space-y-2 mb-8">{month.theme && <ThemeCard {...month} />}</div>
 
 			<div>

--- a/app/routes/jury.tsx
+++ b/app/routes/jury.tsx
@@ -1,6 +1,15 @@
 import React from "react";
 import { db } from "~/server/database.server";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/jury";
+
+export const meta: Route.MetaFunction = () =>
+	pageMeta({
+		title: `Jury Members — ${SITE_NAME}`,
+		description:
+			"The members who set each month's theme and curate nominations down to the ballot the PatientGamers community votes on.",
+		path: "/jury",
+	});
 
 export async function loader() {
 	const result = await db.execute(

--- a/app/routes/jury.tsx
+++ b/app/routes/jury.tsx
@@ -5,9 +5,8 @@ import type { Route } from "./+types/jury";
 
 export const meta: Route.MetaFunction = () =>
 	pageMeta({
-		title: `Jury Members — ${SITE_NAME}`,
-		description:
-			"The members who set each month's theme and curate nominations down to the ballot the PatientGamers community votes on.",
+		title: `Jury Members | ${SITE_NAME}`,
+		description: "The members who set each month's theme and cut the nominations down to a ballot.",
 		path: "/jury",
 	});
 

--- a/app/routes/layout.tsx
+++ b/app/routes/layout.tsx
@@ -5,6 +5,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "~/component
 import { Popover, PopoverContent, PopoverTitle, PopoverTrigger } from "~/components/ui/popover";
 import { requestUserContext } from "~/route-context.server";
 import { getCurrentMonth } from "~/server/month.server";
+import { DISCORD_INVITE_URL } from "~/utils/seo";
 import type { Route } from "./+types/layout";
 
 export async function loader({ context }: Route.LoaderArgs) {
@@ -247,6 +248,15 @@ export default function Layout({ loaderData }: Route.ComponentProps) {
 						.
 					</p>
 					<p className="text-center text-sm text-zinc-400">
+						<a
+							href={DISCORD_INVITE_URL}
+							className="text-blue-400 hover:text-blue-300 hover:underline"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Join the Discord
+						</a>
+						{" · "}
 						<Link to="/jury" className="text-blue-400 hover:text-blue-300 hover:underline">
 							Jury
 						</Link>

--- a/app/routes/nominate.tsx
+++ b/app/routes/nominate.tsx
@@ -26,7 +26,16 @@ import {
 	isDefaultCategoryLabels,
 } from "~/utils/categoryLabels";
 import { findNominationById } from "~/utils/nominations";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/nominate";
+
+export const meta: Route.MetaFunction = () =>
+	pageMeta({
+		title: `Nominate a Game — ${SITE_NAME}`,
+		description: "Put a game forward for this month's theme.",
+		path: "/nominate",
+		noIndex: true,
+	});
 
 interface NominationResponse {
 	error?: string;

--- a/app/routes/nominate.tsx
+++ b/app/routes/nominate.tsx
@@ -31,7 +31,7 @@ import type { Route } from "./+types/nominate";
 
 export const meta: Route.MetaFunction = () =>
 	pageMeta({
-		title: `Nominate a Game — ${SITE_NAME}`,
+		title: `Nominate a Game | ${SITE_NAME}`,
 		description: "Put a game forward for this month's theme.",
 		path: "/nominate",
 		noIndex: true,

--- a/app/routes/og.month.tsx
+++ b/app/routes/og.month.tsx
@@ -1,0 +1,50 @@
+import { getMonth } from "~/server/month.server";
+import { getNominationsForMonth } from "~/server/nomination.server";
+import { OgCard } from "~/server/og-card";
+import { ogResponse, renderOgImage, toDataUri } from "~/server/og.server";
+import { getWinner } from "~/server/winner.server";
+import { monthLabel } from "~/utils/seo";
+import type { Route } from "./+types/og.month";
+
+export async function loader({ params }: Route.LoaderArgs) {
+	const monthId = Number(params.monthId);
+
+	if (Number.isNaN(monthId)) {
+		throw new Response("Invalid month ID", { status: 400 });
+	}
+
+	const month = await getMonth(monthId);
+	const [longWinner, shortWinner, nominations] = await Promise.all([
+		getWinner(monthId, false),
+		getWinner(monthId, true),
+		getNominationsForMonth(monthId),
+	]);
+
+	const winners = [longWinner, shortWinner].filter((winner) => winner !== null);
+	const coverUrls = winners.length
+		? winners.map((winner) => winner.gameCover)
+		: nominations
+				.filter((nomination) => nomination.jurySelected)
+				.slice(0, 3)
+				.map((nomination) => nomination.gameCover);
+
+	const covers = (
+		await Promise.all(coverUrls.filter(Boolean).map((url) => toDataUri(url as string)))
+	).filter((cover) => cover !== null);
+
+	const footnote = winners.length
+		? `Won by ${winners.map((winner) => winner.gameName).join(" · ")}`
+		: `${nominations.length} games nominated`;
+
+	const png = await renderOgImage(
+		<OgCard
+			eyebrow={monthLabel(month.month, month.year)}
+			title={month.theme.name}
+			subtitle={month.theme.description ?? undefined}
+			covers={covers}
+			footnote={footnote}
+		/>,
+	);
+
+	return ogResponse(png);
+}

--- a/app/routes/og.month.tsx
+++ b/app/routes/og.month.tsx
@@ -3,8 +3,11 @@ import { getNominationsForMonth } from "~/server/nomination.server";
 import { OgCard } from "~/server/og-card";
 import { ogResponse, renderOgImage, toDataUri } from "~/server/og.server";
 import { getWinner } from "~/server/winner.server";
+import globalCache from "~/utils/cache.server";
 import { monthLabel } from "~/utils/seo";
 import type { Route } from "./+types/og.month";
+
+const CARD_TTL = 60 * 60 * 1000;
 
 export async function loader({ params }: Route.LoaderArgs) {
 	const monthId = Number(params.monthId);
@@ -13,28 +16,40 @@ export async function loader({ params }: Route.LoaderArgs) {
 		throw new Response("Invalid month ID", { status: 400 });
 	}
 
-	const month = await getMonth(monthId);
-	const [longWinner, shortWinner, nominations] = await Promise.all([
-		getWinner(monthId, false),
-		getWinner(monthId, true),
-		getNominationsForMonth(monthId),
-	]);
+	const cacheKey = `og-card-${monthId}`;
+	const cached = globalCache.get<Uint8Array<ArrayBuffer>>(cacheKey);
 
-	const winners = [longWinner, shortWinner].filter((winner) => winner !== null);
-	const coverUrls = winners.length
-		? winners.map((winner) => winner.gameCover)
-		: nominations
-				.filter((nomination) => nomination.jurySelected)
-				.slice(0, 3)
-				.map((nomination) => nomination.gameCover);
+	if (cached) {
+		return ogResponse(cached);
+	}
+
+	const month = await getMonth(monthId);
+
+	// Same gate the archive page uses: asking for a winner earlier makes
+	// getWinner compute and store one, which a card request has no business doing.
+	const hasResults =
+		month.status === "over" || month.status === "complete" || month.status === "playing";
+
+	const winners = hasResults
+		? (await Promise.all([getWinner(monthId, false), getWinner(monthId, true)])).filter(
+				(winner) => winner !== null,
+			)
+		: [];
+
+	// Winners and shortlisted nominations are the same shape, so the card shows
+	// whichever set the month has reached without treating either as special.
+	const featured = winners.length
+		? { games: winners, footnote: `Won by ${winners.map((w) => w.gameName).join(" · ")}` }
+		: await shortlist(monthId);
 
 	const covers = (
-		await Promise.all(coverUrls.filter(Boolean).map((url) => toDataUri(url as string)))
+		await Promise.all(
+			featured.games
+				.map((game) => game.gameCover)
+				.filter((cover) => cover !== undefined)
+				.map((cover) => toDataUri(cover)),
+		)
 	).filter((cover) => cover !== null);
-
-	const footnote = winners.length
-		? `Won by ${winners.map((winner) => winner.gameName).join(" · ")}`
-		: `${nominations.length} games nominated`;
 
 	const png = await renderOgImage(
 		<OgCard
@@ -42,9 +57,20 @@ export async function loader({ params }: Route.LoaderArgs) {
 			title={month.theme.name}
 			subtitle={month.theme.description ?? undefined}
 			covers={covers}
-			footnote={footnote}
+			footnote={featured.footnote}
 		/>,
 	);
 
+	globalCache.set(cacheKey, png, CARD_TTL);
+
 	return ogResponse(png);
+}
+
+async function shortlist(monthId: number) {
+	const nominations = await getNominationsForMonth(monthId);
+
+	return {
+		games: nominations.filter((nomination) => nomination.jurySelected).slice(0, 3),
+		footnote: `${nominations.length} games nominated`,
+	};
 }

--- a/app/routes/og.month.tsx
+++ b/app/routes/og.month.tsx
@@ -39,7 +39,7 @@ export async function loader({ params }: Route.LoaderArgs) {
 	// Winners and shortlisted nominations are the same shape, so the card shows
 	// whichever set the month has reached without treating either as special.
 	const featured = winners.length
-		? { games: winners, footnote: `Won by ${winners.map((w) => w.gameName).join(" · ")}` }
+		? { games: winners, footnote: `Won by ${winners.map((w) => w.gameName).join(" and ")}` }
 		: await shortlist(monthId);
 
 	const covers = (

--- a/app/routes/og.tsx
+++ b/app/routes/og.tsx
@@ -6,8 +6,7 @@ export async function loader() {
 		<OgCard
 			eyebrow="PatientGamers"
 			title="Game of the Month"
-			subtitle="One short game and one long game, picked together every month."
-			footnote="Nominate · Vote · Play"
+			subtitle="Two games every month, one short and one long."
 		/>,
 	);
 

--- a/app/routes/og.tsx
+++ b/app/routes/og.tsx
@@ -1,0 +1,15 @@
+import { OgCard } from "~/server/og-card";
+import { ogResponse, renderOgImage } from "~/server/og.server";
+
+export async function loader() {
+	const png = await renderOgImage(
+		<OgCard
+			eyebrow="PatientGamers"
+			title="Game of the Month"
+			subtitle="One short game and one long game, picked together every month."
+			footnote="Nominate · Vote · Play"
+		/>,
+	);
+
+	return ogResponse(png);
+}

--- a/app/routes/patience.$date.tsx
+++ b/app/routes/patience.$date.tsx
@@ -3,7 +3,19 @@ import { ChevronLeft, ChevronRight, Calendar, Loader2 } from "lucide-react";
 import { Await, Link, useNavigation } from "react-router";
 import GameCard from "~/components/GameCard";
 import { getReleasesForDate, isValidDate, type Release } from "~/server/releases.server";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/patience.$date.ts";
+
+// One page per calendar day over an unbounded date range, with prev/next links
+// and live IGDB data. Useful to browse, not something to put in the index.
+export const meta: Route.MetaFunction = ({ loaderData }) =>
+	pageMeta({
+		title: `Patient on ${loaderData.displayPatienceDate} — ${SITE_NAME}`,
+		description:
+			"Games that just turned a year old, and are now fair game for patient gamers to pick up.",
+		path: `/patience/${loaderData.patienceDate}`,
+		noIndex: true,
+	});
 
 // Convert a "patience date" (today) to the release date (1 year ago)
 function getReleaseDateFromPatienceDate(patienceDate: string): string {

--- a/app/routes/patience.$date.tsx
+++ b/app/routes/patience.$date.tsx
@@ -10,9 +10,8 @@ import type { Route } from "./+types/patience.$date.ts";
 // and live IGDB data. Useful to browse, not something to put in the index.
 export const meta: Route.MetaFunction = ({ loaderData }) =>
 	pageMeta({
-		title: `Patient on ${loaderData.displayPatienceDate} — ${SITE_NAME}`,
-		description:
-			"Games that just turned a year old, and are now fair game for patient gamers to pick up.",
+		title: `Patient on ${loaderData.displayPatienceDate} | ${SITE_NAME}`,
+		description: "Games that turned a year old on this date.",
 		path: `/patience/${loaderData.patienceDate}`,
 		noIndex: true,
 	});

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -1,4 +1,14 @@
 import React from "react";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
+import type { Route } from "./+types/privacy";
+
+export const meta: Route.MetaFunction = () =>
+	pageMeta({
+		title: `Privacy — ${SITE_NAME}`,
+		description:
+			"What this site stores when you sign in with Discord: your account ID, and only if you nominate or vote.",
+		path: "/privacy",
+	});
 
 export default function Privacy() {
 	return (

--- a/app/routes/privacy.tsx
+++ b/app/routes/privacy.tsx
@@ -4,9 +4,8 @@ import type { Route } from "./+types/privacy";
 
 export const meta: Route.MetaFunction = () =>
 	pageMeta({
-		title: `Privacy — ${SITE_NAME}`,
-		description:
-			"What this site stores when you sign in with Discord: your account ID, and only if you nominate or vote.",
+		title: `Privacy | ${SITE_NAME}`,
+		description: "This site stores your Discord account ID, and only if you nominate or vote.",
 		path: "/privacy",
 	});
 

--- a/app/routes/robots.ts
+++ b/app/routes/robots.ts
@@ -1,0 +1,21 @@
+import { SITE_URL } from "~/utils/seo";
+
+// /patience is deliberately absent: it carries a `noindex` meta tag, and a
+// Disallow here would stop crawlers from ever reading that tag.
+const robots = `User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /auth
+Disallow: /api
+
+Sitemap: ${SITE_URL}/sitemap.xml
+`;
+
+export function loader() {
+	return new Response(robots, {
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+			"Cache-Control": "public, max-age=3600",
+		},
+	});
+}

--- a/app/routes/sitemap.ts
+++ b/app/routes/sitemap.ts
@@ -1,0 +1,30 @@
+import { getMonths } from "~/server/month.server";
+import { SITE_URL } from "~/utils/seo";
+
+const STATIC_PATHS = ["/", "/history", "/stats", "/jury", "/privacy"];
+
+export async function loader() {
+	const months = await getMonths();
+
+	// Months still taking nominations have no archive page yet; /history hides
+	// them too, so listing them here would only advertise thin pages.
+	const paths = [
+		...STATIC_PATHS,
+		...months
+			.filter((month) => month.status !== "nominating")
+			.map((month) => `/history/${month.id}`),
+	];
+
+	const body = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${paths.map((path) => `\t<url><loc>${SITE_URL}${path}</loc></url>`).join("\n")}
+</urlset>
+`;
+
+	return new Response(body, {
+		headers: {
+			"Content-Type": "application/xml; charset=utf-8",
+			"Cache-Control": "public, max-age=3600",
+		},
+	});
+}

--- a/app/routes/stats.tsx
+++ b/app/routes/stats.tsx
@@ -13,7 +13,18 @@ import { useEffect, useId, useRef } from "react";
 import { Card } from "~/components/ui/card";
 import { db } from "~/server/database.server";
 import { uniqueNameGenerator } from "~/server/nameGenerator";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/stats";
+
+export const meta: Route.MetaFunction = ({ loaderData }) => {
+	const { total_nominations, unique_games, total_votes } = loaderData.totalStats;
+
+	return pageMeta({
+		title: `Club Stats — ${SITE_NAME}`,
+		description: `${total_nominations} nominations, ${unique_games} unique games, and ${total_votes} votes cast since the PatientGamers game club began. Winners, jury picks, and voting trends.`,
+		path: "/stats",
+	});
+};
 
 const FULL_SIZE_STYLE = { width: "100%", height: "100%" } as const;
 

--- a/app/routes/stats.tsx
+++ b/app/routes/stats.tsx
@@ -17,11 +17,11 @@ import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/stats";
 
 export const meta: Route.MetaFunction = ({ loaderData }) => {
-	const { total_nominations, unique_games, total_votes } = loaderData.totalStats;
+	const { total_nominations, total_votes } = loaderData.totalStats;
 
 	return pageMeta({
-		title: `Club Stats — ${SITE_NAME}`,
-		description: `${total_nominations} nominations, ${unique_games} unique games, and ${total_votes} votes cast since the PatientGamers game club began. Winners, jury picks, and voting trends.`,
+		title: `Stats | ${SITE_NAME}`,
+		description: `${total_nominations} nominations and ${total_votes} votes since the PatientGamers Discord started picking a game of the month.`,
 		path: "/stats",
 	});
 };

--- a/app/routes/voting.tsx
+++ b/app/routes/voting.tsx
@@ -13,7 +13,16 @@ import type { Nomination } from "~/types";
 import { categoryGameTitle, categoryLabelsFromMonth } from "~/utils/categoryLabels";
 import { findNominationById } from "~/utils/nominations";
 import { buildOrderFromRankings, resolveVotedStatus } from "~/utils/votingOrder";
+import { SITE_NAME, pageMeta } from "~/utils/seo";
 import type { Route } from "./+types/voting";
+
+export const meta: Route.MetaFunction = () =>
+	pageMeta({
+		title: `Vote — ${SITE_NAME}`,
+		description: "Rank this month's ballot.",
+		path: "/voting",
+		noIndex: true,
+	});
 
 type VoteActionResponse = {
 	success: boolean;

--- a/app/routes/voting.tsx
+++ b/app/routes/voting.tsx
@@ -18,7 +18,7 @@ import type { Route } from "./+types/voting";
 
 export const meta: Route.MetaFunction = () =>
 	pageMeta({
-		title: `Vote — ${SITE_NAME}`,
+		title: `Vote | ${SITE_NAME}`,
 		description: "Rank this month's ballot.",
 		path: "/voting",
 		noIndex: true,

--- a/app/server/og-card.tsx
+++ b/app/server/og-card.tsx
@@ -1,0 +1,84 @@
+interface OgCardProps {
+	eyebrow: string;
+	title: string;
+	subtitle?: string;
+	/** Data URIs; remote URLs will not render. */
+	covers?: string[];
+	footnote?: string;
+}
+
+// Satori supports flexbox only, so every container declares display: flex.
+export function OgCard({ eyebrow, title, subtitle, covers = [], footnote }: OgCardProps) {
+	return (
+		<div
+			style={{
+				width: "100%",
+				height: "100%",
+				display: "flex",
+				flexDirection: "column",
+				justifyContent: "space-between",
+				padding: "64px",
+				backgroundColor: "#18181b",
+				color: "#fafafa",
+				fontFamily: "Inter",
+			}}
+		>
+			<div style={{ display: "flex", flexDirection: "column" }}>
+				<div
+					style={{
+						display: "flex",
+						fontSize: 24,
+						fontWeight: 700,
+						letterSpacing: "0.18em",
+						textTransform: "uppercase",
+						color: "#60a5fa",
+					}}
+				>
+					{eyebrow}
+				</div>
+				<div
+					style={{
+						display: "flex",
+						marginTop: 28,
+						fontSize: 76,
+						fontWeight: 700,
+						lineHeight: 1.05,
+						color: "#fafafa",
+					}}
+				>
+					{title}
+				</div>
+				{subtitle ? (
+					<div style={{ display: "flex", marginTop: 20, fontSize: 36, color: "#d4d4d8" }}>
+						{subtitle}
+					</div>
+				) : null}
+			</div>
+
+			<div style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between" }}>
+				<div style={{ display: "flex", flexDirection: "column" }}>
+					{footnote ? (
+						<div style={{ display: "flex", fontSize: 28, color: "#a1a1aa" }}>{footnote}</div>
+					) : null}
+					<div style={{ display: "flex", marginTop: 12, fontSize: 26, color: "#71717a" }}>
+						pg-gotm.com
+					</div>
+				</div>
+
+				{covers.length ? (
+					<div style={{ display: "flex", gap: 20 }}>
+						{covers.map((cover) => (
+							<img
+								key={cover.slice(-32)}
+								src={cover}
+								width={168}
+								height={224}
+								style={{ borderRadius: 12, objectFit: "cover" }}
+							/>
+						))}
+					</div>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/app/server/og.server.ts
+++ b/app/server/og.server.ts
@@ -1,0 +1,66 @@
+import { Resvg, initWasm } from "@resvg/resvg-wasm";
+import satori from "satori";
+import type { ReactNode } from "react";
+
+const OG_WIDTH = 1200;
+const OG_HEIGHT = 630;
+
+// Read straight out of node_modules rather than bundling: the runtime image
+// copies these packages in the same way it copies @libsql.
+const RESVG_WASM = "node_modules/@resvg/resvg-wasm/index_bg.wasm";
+const FONT_REGULAR = "node_modules/@fontsource/inter/files/inter-latin-400-normal.woff";
+const FONT_BOLD = "node_modules/@fontsource/inter/files/inter-latin-700-normal.woff";
+
+async function loadRenderer() {
+	const [wasm, regular, bold] = await Promise.all([
+		Bun.file(RESVG_WASM).arrayBuffer(),
+		Bun.file(FONT_REGULAR).arrayBuffer(),
+		Bun.file(FONT_BOLD).arrayBuffer(),
+	]);
+
+	await initWasm(wasm);
+
+	return [
+		{ name: "Inter", data: regular, weight: 400 as const, style: "normal" as const },
+		{ name: "Inter", data: bold, weight: 700 as const, style: "normal" as const },
+	];
+}
+
+declare global {
+	// initWasm() throws if called twice in a process, and Vite re-instantiates
+	// server modules on change, so this has to outlive the module instance.
+	var ogRenderer: ReturnType<typeof loadRenderer> | undefined;
+}
+
+export async function renderOgImage(element: ReactNode): Promise<Uint8Array<ArrayBuffer>> {
+	globalThis.ogRenderer ??= loadRenderer();
+	const fonts = await globalThis.ogRenderer;
+
+	const svg = await satori(element, { width: OG_WIDTH, height: OG_HEIGHT, fonts });
+
+	return Uint8Array.from(new Resvg(svg).render().asPng());
+}
+
+export function ogResponse(png: Uint8Array<ArrayBuffer>): Response {
+	return new Response(png, {
+		headers: {
+			"Content-Type": "image/png",
+			// Cards change only when a month does; let Cloudflare hold them.
+			"Cache-Control": "public, max-age=3600, s-maxage=86400",
+		},
+	});
+}
+
+/** Satori cannot fetch remote images, so covers are inlined as data URIs. */
+export async function toDataUri(url: string): Promise<string | null> {
+	const response = await fetch(url.startsWith("//") ? `https:${url}` : url);
+
+	if (!response.ok) {
+		return null;
+	}
+
+	const contentType = response.headers.get("content-type") ?? "image/jpeg";
+	const base64 = Buffer.from(await response.arrayBuffer()).toString("base64");
+
+	return `data:${contentType};base64,${base64}`;
+}

--- a/app/server/og.server.ts
+++ b/app/server/og.server.ts
@@ -1,6 +1,7 @@
 import { Resvg, initWasm } from "@resvg/resvg-wasm";
 import satori from "satori";
 import type { ReactNode } from "react";
+import { absoluteUrl } from "~/utils/seo";
 
 const OG_WIDTH = 1200;
 const OG_HEIGHT = 630;
@@ -53,7 +54,7 @@ export function ogResponse(png: Uint8Array<ArrayBuffer>): Response {
 
 /** Satori cannot fetch remote images, so covers are inlined as data URIs. */
 export async function toDataUri(url: string): Promise<string | null> {
-	const response = await fetch(url.startsWith("//") ? `https:${url}` : url);
+	const response = await fetch(absoluteUrl(url));
 
 	if (!response.ok) {
 		return null;

--- a/app/utils/seo.test.ts
+++ b/app/utils/seo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { absoluteImageUrl, monthLabel, pageMeta } from "~/utils/seo";
+import { absoluteUrl, monthLabel, pageMeta } from "~/utils/seo";
 
 function contentOf(descriptors: ReturnType<typeof pageMeta>, key: string): string | undefined {
 	for (const descriptor of descriptors) {
@@ -51,13 +51,17 @@ describe("pageMeta", () => {
 	});
 });
 
-describe("absoluteImageUrl", () => {
+describe("absoluteUrl", () => {
+	test("resolves site paths", () => {
+		expect(absoluteUrl("/history/12")).toBe("https://pg-gotm.com/history/12");
+	});
+
 	test("gives protocol-relative IGDB covers a scheme", () => {
-		expect(absoluteImageUrl("//images.igdb.com/a.jpg")).toBe("https://images.igdb.com/a.jpg");
+		expect(absoluteUrl("//images.igdb.com/a.jpg")).toBe("https://images.igdb.com/a.jpg");
 	});
 
 	test("leaves absolute urls alone", () => {
-		expect(absoluteImageUrl("https://images.igdb.com/a.jpg")).toBe("https://images.igdb.com/a.jpg");
+		expect(absoluteUrl("https://images.igdb.com/a.jpg")).toBe("https://images.igdb.com/a.jpg");
 	});
 });
 

--- a/app/utils/seo.test.ts
+++ b/app/utils/seo.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { absoluteImageUrl, monthLabel, pageMeta } from "~/utils/seo";
+
+function contentOf(descriptors: ReturnType<typeof pageMeta>, key: string): string | undefined {
+	for (const descriptor of descriptors) {
+		if ("name" in descriptor && descriptor.name === key) {
+			return String(descriptor.content);
+		}
+		if ("property" in descriptor && descriptor.property === key) {
+			return String(descriptor.content);
+		}
+	}
+}
+
+describe("pageMeta", () => {
+	const meta = pageMeta({ title: "Stats", description: "Numbers.", path: "/stats" });
+
+	test("canonical and og:url point at the page, not the site root", () => {
+		const canonical = meta.find((d) => "rel" in d && d.rel === "canonical");
+
+		expect(canonical).toEqual({
+			tagName: "link",
+			rel: "canonical",
+			href: "https://pg-gotm.com/stats",
+		});
+		expect(contentOf(meta, "og:url")).toBe("https://pg-gotm.com/stats");
+	});
+
+	test("declares a card image so social embeds are never blank", () => {
+		expect(contentOf(meta, "og:image")).toBe("https://pg-gotm.com/og");
+		expect(contentOf(meta, "twitter:image")).toBe("https://pg-gotm.com/og");
+		expect(contentOf(meta, "twitter:card")).toBe("summary_large_image");
+	});
+
+	test("omits robots unless the page opts out of indexing", () => {
+		expect(contentOf(meta, "robots")).toBeUndefined();
+		expect(
+			contentOf(pageMeta({ title: "T", description: "D", path: "/p", noIndex: true }), "robots"),
+		).toBe("noindex, follow");
+	});
+
+	test("resolves a per-month card image", () => {
+		const monthMeta = pageMeta({
+			title: "T",
+			description: "D",
+			path: "/history/12",
+			image: "/og/month/12",
+		});
+
+		expect(contentOf(monthMeta, "og:image")).toBe("https://pg-gotm.com/og/month/12");
+	});
+});
+
+describe("absoluteImageUrl", () => {
+	test("gives protocol-relative IGDB covers a scheme", () => {
+		expect(absoluteImageUrl("//images.igdb.com/a.jpg")).toBe("https://images.igdb.com/a.jpg");
+	});
+
+	test("leaves absolute urls alone", () => {
+		expect(absoluteImageUrl("https://images.igdb.com/a.jpg")).toBe("https://images.igdb.com/a.jpg");
+	});
+});
+
+describe("monthLabel", () => {
+	test("formats month and year", () => {
+		expect(monthLabel(1, 2025)).toBe("January 2025");
+		expect(monthLabel(12, 2024)).toBe("December 2024");
+	});
+});

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -23,7 +23,7 @@ export function monthLabel(month: number, year: number): string {
 	return `${MONTH_NAMES[month - 1]} ${year}`;
 }
 
-/** Resolves site paths, protocol-relative IGDB covers, and absolute URLs alike. */
+/** Handles site paths, protocol-relative IGDB covers and already-absolute URLs. */
 export function absoluteUrl(path: string): string {
 	return new URL(path, SITE_URL).toString();
 }

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -1,0 +1,74 @@
+import type { MetaDescriptor } from "react-router";
+
+export const SITE_URL = "https://pg-gotm.com";
+export const SITE_NAME = "PG Game of the Month";
+export const DISCORD_INVITE_URL = "https://discord.gg/EJ6bXaz";
+
+const MONTH_NAMES = [
+	"January",
+	"February",
+	"March",
+	"April",
+	"May",
+	"June",
+	"July",
+	"August",
+	"September",
+	"October",
+	"November",
+	"December",
+];
+
+export function monthLabel(month: number, year: number): string {
+	return `${MONTH_NAMES[month - 1]} ${year}`;
+}
+
+export function absoluteUrl(path: string): string {
+	return new URL(path, SITE_URL).toString();
+}
+
+/** IGDB cover URLs are stored protocol-relative; schema and OG tags need a scheme. */
+export function absoluteImageUrl(url: string): string {
+	return url.startsWith("//") ? `https:${url}` : url;
+}
+
+interface PageMetaOptions {
+	title: string;
+	description: string;
+	path: string;
+	/** Root-relative image URL. Defaults to the generic site card. */
+	image?: string;
+	/** Useful to members, not worth indexing (infinite date space, auth walls). */
+	noIndex?: boolean;
+}
+
+export function pageMeta({
+	title,
+	description,
+	path,
+	image = "/og",
+	noIndex = false,
+}: PageMetaOptions): MetaDescriptor[] {
+	const url = absoluteUrl(path);
+	const imageUrl = absoluteUrl(image);
+
+	return [
+		{ title },
+		{ name: "description", content: description },
+		{ tagName: "link", rel: "canonical", href: url },
+		...(noIndex ? [{ name: "robots", content: "noindex, follow" }] : []),
+		{ property: "og:site_name", content: SITE_NAME },
+		{ property: "og:title", content: title },
+		{ property: "og:description", content: description },
+		{ property: "og:type", content: "website" },
+		{ property: "og:url", content: url },
+		{ property: "og:image", content: imageUrl },
+		{ property: "og:image:width", content: "1200" },
+		{ property: "og:image:height", content: "630" },
+		{ property: "og:image:alt", content: title },
+		{ name: "twitter:card", content: "summary_large_image" },
+		{ name: "twitter:title", content: title },
+		{ name: "twitter:description", content: description },
+		{ name: "twitter:image", content: imageUrl },
+	];
+}

--- a/app/utils/seo.ts
+++ b/app/utils/seo.ts
@@ -23,13 +23,9 @@ export function monthLabel(month: number, year: number): string {
 	return `${MONTH_NAMES[month - 1]} ${year}`;
 }
 
+/** Resolves site paths, protocol-relative IGDB covers, and absolute URLs alike. */
 export function absoluteUrl(path: string): string {
 	return new URL(path, SITE_URL).toString();
-}
-
-/** IGDB cover URLs are stored protocol-relative; schema and OG tags need a scheme. */
-export function absoluteImageUrl(url: string): string {
-	return url.startsWith("//") ? `https:${url}` : url;
 }
 
 interface PageMetaOptions {

--- a/bun.lock
+++ b/bun.lock
@@ -6,9 +6,11 @@
       "name": "gotm-remix",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
+        "@fontsource/inter": "^5.3.0",
         "@hello-pangea/dnd": "^18.0.1",
         "@libsql/client": "^0.17.4",
         "@react-router/node": "^8.2.0",
+        "@resvg/resvg-wasm": "^2.6.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "echarts": "^6.1.0",
@@ -17,6 +19,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router": "^8.2.0",
+        "satori": "^0.29.0",
         "string-similarity": "^4.0.4",
         "tailwind-merge": "^3.6.0",
       },
@@ -120,6 +123,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.9", "", { "dependencies": { "@floating-ui/dom": "^1.8.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.12", "", {}, "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww=="],
+
+    "@fontsource/inter": ["@fontsource/inter@5.3.0", "", {}, "sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g=="],
 
     "@hello-pangea/dnd": ["@hello-pangea/dnd@18.0.1", "", { "dependencies": { "@babel/runtime": "^7.26.7", "css-box-model": "^1.2.1", "raf-schd": "^4.0.3", "react-redux": "^9.2.0", "redux": "^5.0.1" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ=="],
 
@@ -337,6 +342,8 @@
 
     "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.13.3", "", {}, "sha512-UfjOXed/DQteaM5VyTfqTeGpHwyL2J5aoRGY6cydip4tt1ehNNeSwuXCC7AEGE0RWBs/7bgKxYkL/B/+UDe4AA=="],
 
+    "@resvg/resvg-wasm": ["@resvg/resvg-wasm@2.6.2", "", {}, "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw=="],
+
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
@@ -368,6 +375,8 @@
     "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@shuding/opentype.js": ["@shuding/opentype.js@1.4.0-beta.0", "", { "dependencies": { "fflate": "^0.7.3", "string.prototype.codepointat": "^0.2.1" }, "bin": { "ot": "bin/ot" } }, "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
 
@@ -463,11 +472,15 @@
 
     "babel-plugin-react-compiler": ["babel-plugin-react-compiler@1.0.0", "", { "dependencies": { "@babel/types": "^7.26.0" } }, "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw=="],
 
+    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.38", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001799", "", {}, "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw=="],
 
@@ -477,13 +490,25 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
+    "css-background-parser": ["css-background-parser@0.1.0", "", {}, "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA=="],
+
     "css-box-model": ["css-box-model@1.2.1", "", { "dependencies": { "tiny-invariant": "^1.0.6" } }, "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw=="],
+
+    "css-box-shadow": ["css-box-shadow@1.0.0-3", "", {}, "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg=="],
+
+    "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
+
+    "css-gradient-parser": ["css-gradient-parser@0.0.17", "", {}, "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg=="],
+
+    "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
@@ -499,11 +524,15 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.375", "", {}, "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q=="],
 
+    "emoji-regex-xs": ["emoji-regex-xs@2.0.1", "", {}, "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
 
     "es-module-lexer": ["es-module-lexer@2.1.0", "", {}, "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "exit-hook": ["exit-hook@5.1.0", "", {}, "sha512-INjr2xyxHo7bhAqf5ong++GZPPnpcuBcaXUKt03yf7Fie9yWD7FapL4teOU0+awQazGs5ucBh7xWs/AD+6nhog=="],
 
@@ -512,6 +541,8 @@
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.7.5", "", {}, "sha512-QieYf//cis6ywHNi5qW1+PXPQ4bC+XVJAtS4AXIML8P76GroEiOxm/oQtn1f02UkJY1+KsXMJcC+R2v/Eg4G3g=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
@@ -522,6 +553,8 @@
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "hex-rgb": ["hex-rgb@4.3.0", "", {}, "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw=="],
 
     "isbot": ["isbot@5.2.0", "", {}, "sha512-gbZiGCb4B5xaoxg9mS7koAyRdvJnArk10VLSHOgz6rtBG93/pi1xOFaVvXMKZ7JXgyZ8zAbNRK5uIBdIUTFSqw=="],
 
@@ -563,6 +596,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
+
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
@@ -589,6 +624,10 @@
 
     "p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
 
+    "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+
+    "parse-css-color": ["parse-css-color@0.2.1", "", { "dependencies": { "color-name": "^1.1.4", "hex-rgb": "^4.1.0" } }, "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg=="],
+
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -602,6 +641,8 @@
     "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
     "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
 
@@ -629,6 +670,8 @@
 
     "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
 
+    "satori": ["satori@0.29.0", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-fPAfrwNaIQ7EsJLhY382STEqpczN6ZEH9NsKXDQgRcxUXNNPB73iAjSshzFwTaaScT68pxV0pmG6TBzDQ4sEGw=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
@@ -639,6 +682,8 @@
 
     "string-similarity": ["string-similarity@4.0.4", "", {}, "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ=="],
 
+    "string.prototype.codepointat": ["string.prototype.codepointat@0.2.1", "", {}, "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="],
+
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
@@ -646,6 +691,8 @@
     "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
@@ -662,6 +709,8 @@
     "unbash": ["unbash@4.0.1", "", {}, "sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -682,6 +731,8 @@
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 

--- a/knip.json
+++ b/knip.json
@@ -6,7 +6,8 @@
 	"ignoreDependencies": [
 		"@babel/preset-typescript",
 		"babel-plugin-react-compiler",
-		"tw-animate-css"
+		"tw-animate-css",
+		"@fontsource/inter"
 	],
 	"ignoreExportsUsedInFile": {
 		"interface": true,

--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.6.0",
+		"@fontsource/inter": "^5.3.0",
 		"@hello-pangea/dnd": "^18.0.1",
 		"@libsql/client": "^0.17.4",
 		"@react-router/node": "^8.2.0",
+		"@resvg/resvg-wasm": "^2.6.2",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"echarts": "^6.1.0",
@@ -30,6 +32,7 @@
 		"react": "^19.2.7",
 		"react-dom": "^19.2.7",
 		"react-router": "^8.2.0",
+		"satori": "^0.29.0",
 		"string-similarity": "^4.0.4",
 		"tailwind-merge": "^3.6.0"
 	},

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,11 +1,13 @@
 {
-	"name": "",
-	"short_name": "",
+	"name": "PG Game of the Month",
+	"short_name": "PG GOTM",
+	"description": "The PatientGamers Discord picks one short game and one long game to play together every month.",
+	"start_url": "/",
 	"icons": [
 		{ "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
 		{ "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
 	],
-	"theme_color": "#ffffff",
-	"background_color": "#ffffff",
+	"theme_color": "#18181b",
+	"background_color": "#18181b",
 	"display": "standalone"
 }

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
 	"name": "PG Game of the Month",
 	"short_name": "PG GOTM",
-	"description": "The PatientGamers Discord picks one short game and one long game to play together every month.",
+	"description": "The PatientGamers Discord picks two games to play every month, one short and one long.",
 	"start_url": "/",
 	"icons": [
 		{ "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,9 @@ export default defineConfig(({ command }) => ({
 		reactRouter(),
 		babel({
 			include: /\.[jt]sx?$/,
-			exclude: /node_modules/,
+			// app/server is never rendered by React — satori invokes those components
+			// directly, so React Compiler's useMemoCache has no dispatcher to reach.
+			exclude: [/node_modules/, /app\/server\//],
 			babelConfig: {
 				presets: ["@babel/preset-typescript"],
 				plugins: [["babel-plugin-react-compiler", ReactCompilerConfig]],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(({ command }) => ({
 		reactRouter(),
 		babel({
 			include: /\.[jt]sx?$/,
-			// app/server is never rendered by React — satori invokes those components
+			// app/server is never rendered by React. Satori invokes those components
 			// directly, so React Compiler's useMemoCache has no dispatcher to reach.
 			exclude: [/node_modules/, /app\/server\//],
 			babelConfig: {


### PR DESCRIPTION
Worked the site through a technical SEO audit checklist and fixed what it turned up. It scored 42/100 on that rubric before this.

## What was broken

- **Every page served `<title>PG GOTM</title>`** and the same description. `/`, `/history`, `/history/12`, `/stats` were all identical, with no canonical tag anywhere.
- **`twitter:card` was `summary_large_image` with no image declared**, so every Discord paste of a link unfurled blank.
- **`og:url` was hardcoded to the site root** on every page.
- **`/sitemap.xml` 404'd** and `robots.txt` fell through to Cloudflare's managed content-signals file, which carries no directives and no `Sitemap:` line.
- **The favicons and `site.webmanifest` in `public/` were never linked.** Root had no `links` export, so only `/favicon.ico` worked, by browser convention. The manifest also had empty `name`/`short_name` and white theme colours against a zinc-900 site.
- **35 `<link rel="preload" as="image">` on the homepage.** React 19 hoists server-rendered `<img>` into preloads, and all 35 competed with the LCP element.
- **No structured data at all.**
- **Nothing on the site said what PG GOTM is.** The homepage opened directly into a nominations list.

## What this does

Per-route `meta` with request-independent canonicals, `WebSite`/`Organization` JSON-LD site-wide, an `ItemList` of `VideoGame` per archive month, an app-served `robots.txt` plus a DB-driven `sitemap.xml`, and generated 1200x630 social cards per month showing the theme, winners and cover art.

`/patience` gets `noindex, follow` rather than a robots `Disallow`. It spans an unbounded date range with live IGDB data, and disallowing it would stop crawlers from ever reading the noindex.

The homepage now explains the short/long split and the ranked-choice vote, with the Discord invite as the call to action.

### Notes for review

- **Social cards** use `satori` plus `@resvg/resvg-wasm` (wasm, not the native binding) so the server bundle stays portable. The wasm and Inter `.woff` files are read from `node_modules` at runtime and copied into the runtime image exactly like `@libsql` already is: two `COPY` lines, no binaries committed.
- **`app/server` is excluded from the React Compiler** in `vite.config.ts`. Satori invokes those components directly, so an injected `useMemoCache` has no dispatcher and throws. This only surfaced running through Vite, not in a standalone render.
- **`initWasm()` throws if called twice per process** and Vite re-instantiates server modules on change, so the renderer promise is held on `globalThis`.
- **Card requests no longer ask for a winner unless the month has reached a results state.** `getWinner` computes and stores one on a miss, so an unconditional call meant a crawler hitting a card during `voting` could trigger a write that the archive page deliberately avoids, and it cost four queries on months with no winners. Rendered cards are held in the repo's existing TTL cache.
- **Copy is deliberately plain.** The Discord this serves is strongly anti-AI, so the last commit strips em dashes, three-item lists, slogans and filler words from every user-visible string.

## Verification

Ran against a locally seeded SQLite copy of the schema, not production.

- `bun run typecheck`, `bun run lint`, `bun test` (35 pass), `bun run knip` all clean. Knip's remaining findings predate this branch.
- `bun run build`, then both Dockerfile bundle steps, then served the production bundle: `/`, `/robots.txt`, `/sitemap.xml`, `/og`, `/og/month/1` all 200, cards returning `image/png`.
- Confirmed unique title, description and canonical per page, both JSON-LD blocks parsing, homepage image preloads 35 to 0, a single `h1` per page, and `noindex` present only on `/patience` and the auth-gated routes.
- Card render: 3.6s cold, 10ms warm. A month with no winners renders in 23ms and issues no winner queries.
- Second review pass over the whole branch diff, no blocking findings.

## Not covered

Security headers (HSTS, `X-Content-Type-Options`, `Referrer-Policy`) and `Cache-Control` on HTML are still absent. That belongs in `server.ts` or Cloudflare and felt out of scope here. `HEAD` requests also return 200 with no `Content-Type` (`app/entry.server.tsx:91`), which affects unfurlers that probe with `HEAD` first.
