### PR TITLE
fix(server): send a content type on HEAD responses

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -89,6 +89,10 @@ export default function handleRequest(
 	routerContext: EntryContext,
 	_loadContext: RouterContextProvider,
 ) {
+	// A HEAD response has to describe the document a GET would return, so the
+	// content type belongs here rather than only on the streaming path.
+	responseHeaders.set("Content-Type", "text/html");
+
 	if (request.method.toUpperCase() === "HEAD") {
 		return new Response(null, {
 			status: responseStatusCode,
@@ -121,8 +125,6 @@ export default function handleRequest(
 						},
 					});
 					const stream = createReadableStreamFromReadable(body);
-
-					responseHeaders.set("Content-Type", "text/html");
 
 					pipe(body);
 


### PR DESCRIPTION
Follow-up to #28, which flagged this but left it out of scope.

## The bug

`app/entry.server.tsx` short-circuits HEAD requests and returns `responseHeaders` as-is, but `Content-Type` was only set later, inside the streaming path's ready callback. So every HEAD request to a document route answered 200 with no content type at all.

Reproduced against the live site and locally:

```
$ curl -sI https://pg-gotm.com/
HTTP/2 200
content-length: 0
cf-cache-status: DYNAMIC
...                       # no content-type
```

Link unfurlers and crawlers that probe with HEAD before fetching had nothing telling them the URL was an HTML document.

## The fix

Both paths describe the same document, so the header is set once before the branch rather than on one side of it. Net four lines.

## Proof

Local run against a seeded SQLite copy of the schema, before and after:

| Request | Before | After |
|---|---|---|
| `HEAD /` | `200`, no content type | `200`, `text/html` |
| `GET /` | `200`, `text/html` | `200`, `text/html` (unchanged) |
| `HEAD /history/1` | `200`, no content type | `200`, `text/html` |
| `HEAD /og/month/1` | `200`, `image/png` | `200`, `image/png` (unchanged) |

Resource routes never reached this handler, so the generated cards are unaffected. `bun run typecheck`, `bun run lint`, `bun test` (35 pass) and `bun run build` all clean.

No unit test added: the seam takes an `EntryContext` and a `RouterContextProvider`, so a test here would assert against mocks rather than the transport. The table above is the real HTTP behaviour, which is where the bug actually lived.

## Known remainder

`HEAD` still returns `Content-Length: 0`, added by the runtime for a null body. `GET` streams chunked with no known length, so there is no correct value to mirror and no clean way to strip the header. It is misleading in theory; in practice the unfurlers that matter issue `GET`, and the missing content type was the blocking half.