### PR TITLE
chore(server): set security headers and keep pages out of shared caches

### DIFF
--- a/app/server/runtime.server.test.ts
+++ b/app/server/runtime.server.test.ts
@@ -1,9 +1,43 @@
 import { describe, expect, test } from "bun:test";
-import { shouldScheduleProductionJobs } from "./runtime.server";
+import { applyResponseDefaults, shouldScheduleProductionJobs } from "./runtime.server";
 
 describe("server runtime jobs", () => {
 	test("only production schedules external notification jobs", () => {
 		expect(shouldScheduleProductionJobs("development")).toBe(false);
 		expect(shouldScheduleProductionJobs("production")).toBe(true);
+	});
+});
+
+describe("applyResponseDefaults", () => {
+	test("sets security headers on every response", () => {
+		const { headers } = applyResponseDefaults(new Response("hi"));
+
+		expect(headers.get("X-Content-Type-Options")).toBe("nosniff");
+		expect(headers.get("X-Frame-Options")).toBe("DENY");
+		expect(headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+		expect(headers.get("Strict-Transport-Security")).toBe("max-age=31536000");
+	});
+
+	test("keeps pages out of shared caches", () => {
+		const response = applyResponseDefaults(
+			new Response("<html></html>", { headers: { "Content-Type": "text/html" } }),
+		);
+
+		expect(response.headers.get("Cache-Control")).toBe("private, no-cache");
+	});
+
+	test("leaves a route's own caching policy alone", () => {
+		const response = applyResponseDefaults(
+			new Response("png", { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400" } }),
+		);
+
+		expect(response.headers.get("Cache-Control")).toBe("public, max-age=3600, s-maxage=86400");
+	});
+
+	test("does not disturb the body or status", async () => {
+		const response = applyResponseDefaults(new Response("ok", { status: 404 }));
+
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe("ok");
 	});
 });

--- a/app/server/runtime.server.ts
+++ b/app/server/runtime.server.ts
@@ -26,6 +26,15 @@ const staticDirectories = [
 	},
 ];
 
+const securityHeaders = {
+	"X-Content-Type-Options": "nosniff",
+	"X-Frame-Options": "DENY",
+	"Referrer-Policy": "strict-origin-when-cross-origin",
+	// Browsers ignore this over plain HTTP, so it costs nothing in development.
+	// No includeSubDomains: nothing here knows what runs on a subdomain.
+	"Strict-Transport-Security": "max-age=31536000",
+} as const;
+
 let runtimeStarted = false;
 
 export type ServerMode = keyof typeof defaultPortByMode;
@@ -67,12 +76,27 @@ export function createAppHandler(build: ServerBuildLoader, mode: ServerMode) {
 			const response = await respond(request);
 
 			if (response) {
-				return response;
+				return applyResponseDefaults(response);
 			}
 		}
 
-		return handler(request, createLoadContext());
+		return applyResponseDefaults(await handler(request, createLoadContext()));
 	};
+}
+
+export function applyResponseDefaults(response: Response) {
+	for (const [name, value] of Object.entries(securityHeaders)) {
+		response.headers.set(name, value);
+	}
+
+	// Pages render the signed-in member's name and avatar, so no shared cache may
+	// hold them. Routes that state their own policy, like the social cards and the
+	// static assets, keep it.
+	if (!response.headers.has("Cache-Control")) {
+		response.headers.set("Cache-Control", "private, no-cache");
+	}
+
+	return response;
 }
 
 export function startServerRuntime(mode: ServerMode = getServerMode()) {


### PR DESCRIPTION
Last item from the audit behind #28. Closes out the "not covered" list there.

## The problem

Two things, both visible with `curl -D -`:

1. **No security headers on any response.** No `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` or HSTS.
2. **No caching policy on documents.** The nav renders the signed-in member's pseudonym and avatar, so a shared cache was free to store one member's page and serve it to somebody else. Cloudflare happens to treat these as `DYNAMIC` today, which is luck rather than instruction.

## The fix

`createAppHandler` is the one seam both `server.ts` and `dev-server.ts` pass through, so the defaults live there rather than in `server.ts`, which would only cover production.

Documents get `Cache-Control: private, no-cache`. `no-cache` rather than `no-store` so back/forward navigation still works. Any route that states its own policy keeps it, so the social cards, `robots.txt`, the sitemap, `/ping` and the fingerprinted assets are untouched.

## Proof

Four unit tests on `applyResponseDefaults` cover the header set, the document default, an explicit policy surviving, and body/status passing through. `bun test` 39 pass, plus typecheck, lint and build clean.

Observed headers, development server:

| Route | Cache-Control | Security headers |
|---|---|---|
| `/` | `private, no-cache` (new) | all four |
| `/robots.txt` | `public, max-age=3600` (own) | all four |
| `/sitemap.xml` | `public, max-age=3600` (own) | all four |
| `/og/month/1` | `public, max-age=3600, s-maxage=86400` (own) | all four |
| `/ping` | `no-store` (own) | all four |

And against the production bundle, where static serving is active:

| Route | Result |
|---|---|
| `/assets/<hashed>.js` | `public, max-age=31536000, immutable` kept |
| `/favicon.ico` | `public, max-age=3600` kept |
| `/voting` | `302` to `/auth/discord` preserved, `private, no-cache` applied |

## Deliberately not here

**No Content-Security-Policy.** React Router injects inline hydration scripts, so anything useful needs a nonce threaded through the document response. A permissive `script-src 'unsafe-inline'` would be theatre. Worth its own change.

**HSTS omits `includeSubDomains`.** Nothing in this repo knows what is served on a subdomain, and getting that wrong is not easily reversible. `max-age=31536000` on the apex only.