### PR TITLE
feat(server): add a nonce-based content security policy

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -18,6 +18,24 @@ export const streamTimeout = 30_000;
 const ROUTE_TIMING_LOG_MS = 250;
 const REQUEST_TIMING_LOG_MS = 500;
 
+// style-src allows inline because CSS is set through style attributes, which a
+// nonce cannot cover. Covers are served by IGDB and avatars by Discord; both are
+// listed without a scheme because cover URLs are stored protocol-relative, and a
+// bare host still resolves to https on an https page.
+const contentSecurityPolicy = (nonce: string) =>
+	[
+		"default-src 'self'",
+		`script-src 'self' 'nonce-${nonce}'`,
+		"style-src 'self' 'unsafe-inline'",
+		"img-src 'self' images.igdb.com cdn.discordapp.com",
+		"font-src 'self'",
+		"connect-src 'self'",
+		"form-action 'self'",
+		"frame-ancestors 'none'",
+		"base-uri 'self'",
+		"object-src 'none'",
+	].join("; ");
+
 function getPathname(requestUrl: string) {
 	return new URL(requestUrl).pathname;
 }
@@ -93,6 +111,10 @@ export default function handleRequest(
 	// content type belongs here rather than only on the streaming path.
 	responseHeaders.set("Content-Type", "text/html");
 
+	const nonce = crypto.randomUUID();
+
+	responseHeaders.set("Content-Security-Policy", contentSecurityPolicy(nonce));
+
 	if (request.method.toUpperCase() === "HEAD") {
 		return new Response(null, {
 			status: responseStatusCode,
@@ -113,8 +135,10 @@ export default function handleRequest(
 		);
 
 		const { pipe, abort } = renderToPipeableStream(
-			<ServerRouter context={routerContext} url={request.url} />,
+			// ServerRouter passes the nonce down to Scripts and ScrollRestoration.
+			<ServerRouter context={routerContext} url={request.url} nonce={nonce} />,
 			{
+				nonce,
 				[readyOption]() {
 					shellRendered = true;
 					const body = new PassThrough({


### PR DESCRIPTION
#30 deliberately left CSP out, because React Router injects inline hydration scripts and a policy with `script-src 'unsafe-inline'` would have been decoration. This does it properly.

## How the nonce is threaded

No loader plumbing or React context needed. `<ServerRouter nonce>` passes the value down to `<Scripts>` and `<ScrollRestoration>`, and `renderToPipeableStream` takes the same nonce for React's own bootstrap script. One `crypto.randomUUID()` per request in `entry.server.tsx` covers every inline script in the document.

## The policy

```
default-src 'self'
script-src 'self' 'nonce-<per-request>'
style-src 'self' 'unsafe-inline'
img-src 'self' images.igdb.com cdn.discordapp.com
font-src 'self'
connect-src 'self'
form-action 'self'
frame-ancestors 'none'
base-uri 'self'
object-src 'none'
```

Two decisions worth reviewing:

**`img-src` hosts carry no scheme.** My first attempt used `https://images.igdb.com` and it blocked every game cover. Cover URLs are stored protocol-relative (`//images.igdb.com/...`), so on an http page they resolve to `http://` and miss a scheme-qualified source. Production is https and would have worked, which is exactly why this was worth catching: it would have left local development permanently broken and the policy never properly exercised. A bare host still resolves to https on an https page, so this is correct in both.

**`style-src` keeps `unsafe-inline`.** Styles are applied through style attributes (`style={{ colorScheme: "dark" }}`, and ECharts sizing its containers). Nonces do not apply to attributes, so there is no stricter option short of removing inline styles from the app. Far less dangerous than the script-src equivalent.

## Proof

Driven with real headless Chrome against the production bundle, console captured, six pages:

| Page | CSP violations | JSON-LD in DOM |
|---|---|---|
| `/` | 0 | 1 |
| `/stats` | 0 | 1 |
| `/history/1` | 0 | 1 |
| `/patience/2025-06-01` | 0 | 1 |
| `/jury` | 0 | 1 |
| `/privacy` | 0 | 1 |

The dev server was checked the same way: 0 violations, no console errors, so Vite's HMR client is unaffected.

Nonce invariants, from a single request: the header nonce and the HTML nonce match, exactly one distinct nonce appears in the document, and it changes between requests.

`/stats` was screenshotted to confirm the ECharts bar and donut charts actually draw, which only happens if hydration ran, so the nonce is genuinely working rather than the page merely failing quietly.

The JSON-LD blocks carry no nonce and do not need one: a `<script>` with a non-executable type is never prepared for execution, so `script-src` is never consulted. Confirmed in the browser rather than assumed, since getting that wrong would have silently removed the structured data added in #28.

`bun run typecheck`, `bun run lint`, `bun test` (39 pass), `bun run knip` and `bun run build` all clean.

## Note

No unit test. The policy string is a constant, so asserting its contents would restate it; the nonce invariant needs a full document render through `EntryContext`. The browser run above is the real proof, and it is what caught the `img-src` bug.